### PR TITLE
Fix Folia threading and cross-server teleport issues

### DIFF
--- a/src/main/java/fr/elias/oreoEssentials/modules/nametag/ChatBubbleService.java
+++ b/src/main/java/fr/elias/oreoEssentials/modules/nametag/ChatBubbleService.java
@@ -39,7 +39,6 @@ import java.util.concurrent.ConcurrentHashMap;
  */
 public final class ChatBubbleService implements Listener {
 
-    // ── Config ────────────────────────────────────────────────────────────────
     private boolean enabled;
     private double yOffset;
     private double viewRangeSquared;
@@ -57,25 +56,18 @@ public final class ChatBubbleService implements Listener {
     private List<NametageCondition> senderConditions;
     private List<NametageCondition> viewerConditions;
 
-    // ── Background icon config ────────────────────────────────────────────────
     private boolean bgIconEnabled;
     private String bgIconText;
     private float bgIconScale;
     private double bgIconOffsetX;
     private double bgIconOffsetY;
 
-    // ── State ─────────────────────────────────────────────────────────────────
-    /** owner UUID → main bubble entity UUID */
     private final ConcurrentHashMap<UUID, UUID> activeBubbles = new ConcurrentHashMap<>();
-    /** owner UUID → background icon entity UUID */
     private final ConcurrentHashMap<UUID, UUID> activeBgIcons = new ConcurrentHashMap<>();
-    /** owner UUID → MiniMessage color tag chosen by the player (e.g. "<red>") */
     private final ConcurrentHashMap<UUID, String> playerBubbleColors = new ConcurrentHashMap<>();
 
     private final OreoEssentials plugin;
     private static final MiniMessage MM = MiniMessage.miniMessage();
-
-    // ── Constructor ───────────────────────────────────────────────────────────
 
     public ChatBubbleService(OreoEssentials plugin, FileConfiguration config) {
         this.plugin = plugin;
@@ -88,8 +80,6 @@ public final class ChatBubbleService implements Listener {
             plugin.getLogger().info("[ChatBubble] Disabled in config.");
         }
     }
-
-    // ── Config ────────────────────────────────────────────────────────────────
 
     private void loadConfig(FileConfiguration config) {
         ConfigurationSection s = config.getConfigurationSection("chat-bubbles");
@@ -126,7 +116,6 @@ public final class ChatBubbleService implements Listener {
         this.senderConditions = NametageCondition.parseList(s, "sender-conditions");
         this.viewerConditions = NametageCondition.parseList(s, "viewer-conditions");
 
-        // ── Background icon ───────────────────────────────────────────────────
         ConfigurationSection bgSec = s.getConfigurationSection("background-icon");
         if (bgSec != null) {
             this.bgIconEnabled = bgSec.getBoolean("enabled", false);
@@ -143,22 +132,14 @@ public final class ChatBubbleService implements Listener {
         }
     }
 
-    // ── Event handler ─────────────────────────────────────────────────────────
-
-    // ignoreCancelled = false because the OreoEssentials chat channel system cancels
-    // every AsyncChatEvent at HIGHEST priority to reformat it — we still want bubbles.
     @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = false)
     public void onChat(AsyncChatEvent event) {
         if (!enabled) return;
         Player sender = event.getPlayer();
 
-        // Skip GUI input (AH price, order qty, etc.) — those messages start with digits or
-        // are cancelled without being displayed. Simple heuristic: skip command-like input.
         String rawMessage = PlainTextComponentSerializer.plainText().serialize(event.message());
         if (rawMessage.startsWith("/")) return;
 
-        // Condition check uses Bukkit API (hasPermission, getGameMode, getWorld) — must run sync.
-        // Schedule on the player's entity thread (we're async here) and evaluate conditions there.
         OreScheduler.runForEntity(plugin, sender, () -> {
             if (!sender.isOnline()) return;
             if (!NametageCondition.evaluateAll(senderConditions, sender)) return;
@@ -176,14 +157,10 @@ public final class ChatBubbleService implements Listener {
         removeBubble(event.getPlayer().getUniqueId());
     }
 
-    // ── Bubble lifecycle ──────────────────────────────────────────────────────
-
     private void spawnBubble(Player sender, String rawMessage) {
         removeBubble(sender.getUniqueId());
 
         String displayText = truncateToMaxLines(rawMessage);
-
-        // Apply per-player color if set, sandwiched between server-wide prefix/suffix
         String playerColor = playerBubbleColors.get(sender.getUniqueId());
         String coloredMsg = (playerColor != null && !playerColor.isEmpty())
                 ? (playerColor + displayText + "<reset>")
@@ -200,51 +177,51 @@ public final class ChatBubbleService implements Listener {
         OreScheduler.runAtLocation(plugin, spawnLoc, () -> {
             if (!sender.isOnline()) return;
 
-            // ── Background icon (spawned first = lower entity ID = renders behind text) ──
             if (bgIconEnabled && !bgIconText.isEmpty()) {
-                Location bgLoc = sender.getLocation().add(bgIconOffsetX, yOffset + bgIconOffsetY, 0);
-                TextDisplay bgDisplay = (TextDisplay) bgLoc.getWorld()
-                        .spawnEntity(bgLoc, EntityType.TEXT_DISPLAY);
+                Location bgLoc = spawnLoc.clone().add(bgIconOffsetX, bgIconOffsetY, 0);
+                TextDisplay bgDisplay = (TextDisplay) bgLoc.getWorld().spawnEntity(bgLoc, EntityType.TEXT_DISPLAY);
                 configureBgIcon(bgDisplay);
 
-                for (Player viewer : Bukkit.getOnlinePlayers()) viewer.hideEntity(plugin, bgDisplay);
+                for (Player viewer : Bukkit.getOnlinePlayers()) {
+                    OreScheduler.runForEntity(plugin, viewer, () -> viewer.hideEntity(plugin, bgDisplay));
+                }
                 activeBgIcons.put(sender.getUniqueId(), bgDisplay.getUniqueId());
                 updateEntityVisibility(sender, bgDisplay);
                 startPositionTracker(sender, bgDisplay, bgIconOffsetX, yOffset + bgIconOffsetY);
                 animateAppear(bgDisplay, null);
             }
 
-            // ── Main text bubble ──────────────────────────────────────────────
-            TextDisplay display = (TextDisplay) spawnLoc.getWorld()
-                    .spawnEntity(spawnLoc, EntityType.TEXT_DISPLAY);
+            TextDisplay display = (TextDisplay) spawnLoc.getWorld().spawnEntity(spawnLoc, EntityType.TEXT_DISPLAY);
             configureBubbleEntity(display, text);
 
-            for (Player viewer : Bukkit.getOnlinePlayers()) viewer.hideEntity(plugin, display);
+            for (Player viewer : Bukkit.getOnlinePlayers()) {
+                OreScheduler.runForEntity(plugin, viewer, () -> viewer.hideEntity(plugin, display));
+            }
             activeBubbles.put(sender.getUniqueId(), display.getUniqueId());
             updateEntityVisibility(sender, display);
 
-            animateAppear(display, () -> {
-                OreScheduler.runLater(plugin, () -> {
-                    // Disappear main bubble
-                    if (display.isValid()) {
-                        animateDisappear(display, () -> {
-                            display.remove();
-                            activeBubbles.remove(sender.getUniqueId(), display.getUniqueId());
-                        });
-                    }
-                    // Disappear bg icon in sync
-                    UUID bgUuid = activeBgIcons.get(sender.getUniqueId());
-                    if (bgUuid != null) {
-                        org.bukkit.entity.Entity bgEnt = Bukkit.getEntity(bgUuid);
-                        if (bgEnt instanceof TextDisplay bgDisp && bgDisp.isValid()) {
+            animateAppear(display, () -> OreScheduler.runLaterForEntity(plugin, display, () -> {
+                if (display.isValid()) {
+                    animateDisappear(display, () -> {
+                        if (display.isValid()) display.remove();
+                        activeBubbles.remove(sender.getUniqueId(), display.getUniqueId());
+                    });
+                }
+
+                UUID bgUuid = activeBgIcons.get(sender.getUniqueId());
+                if (bgUuid != null) {
+                    org.bukkit.entity.Entity bgEnt = Bukkit.getEntity(bgUuid);
+                    if (bgEnt instanceof TextDisplay bgDisp) {
+                        OreScheduler.runForEntity(plugin, bgDisp, () -> {
+                            if (!bgDisp.isValid()) return;
                             animateDisappear(bgDisp, () -> {
-                                bgDisp.remove();
+                                if (bgDisp.isValid()) bgDisp.remove();
                                 activeBgIcons.remove(sender.getUniqueId(), bgUuid);
                             });
-                        }
+                        });
                     }
-                }, stayTicks);
-            });
+                }
+            }, stayTicks));
 
             startPositionTracker(sender, display, 0, yOffset);
         });
@@ -255,7 +232,6 @@ public final class ChatBubbleService implements Listener {
         display.setGravity(false);
         display.setInvulnerable(true);
         display.addScoreboardTag("oe_bubble");
-
         display.text(text);
         display.setShadowed(shadow);
         display.setSeeThrough(seeThrough);
@@ -292,7 +268,6 @@ public final class ChatBubbleService implements Listener {
         display.setBackgroundColor(Color.fromARGB(0));
         display.setTextOpacity((byte) 0);
 
-        // Apply scale via Transformation
         if (bgIconScale != 1.0f) {
             Transformation t = display.getTransformation();
             t.getScale().set(bgIconScale, bgIconScale, bgIconScale);
@@ -303,49 +278,68 @@ public final class ChatBubbleService implements Listener {
         display.setViewRange((float) Math.min(viewRange, 1.0));
     }
 
-    /** Shows or hides a TextDisplay to each online player based on viewer conditions. */
     private void updateEntityVisibility(Player sender, TextDisplay display) {
-        for (Player viewer : Bukkit.getOnlinePlayers()) {
-            boolean shouldShow = canViewerSee(sender, viewer);
-            if (shouldShow) {
-                OreScheduler.runForEntity(plugin, viewer, () -> viewer.showEntity(plugin, display));
-            } else {
-                OreScheduler.runForEntity(plugin, viewer, () -> viewer.hideEntity(plugin, display));
+        // Capture the sender position from the sender's region, then evaluate each viewer on
+        // that viewer's own entity scheduler. This avoids cross-region Player access on Folia.
+        OreScheduler.runForEntity(plugin, sender, () -> {
+            if (!sender.isOnline()) return;
+            final Location senderLoc = sender.getLocation().clone();
+            final UUID senderWorld = senderLoc.getWorld() != null ? senderLoc.getWorld().getUID() : null;
+
+            for (Player viewer : Bukkit.getOnlinePlayers()) {
+                OreScheduler.runForEntity(plugin, viewer, () -> {
+                    if (!viewer.isOnline() || senderWorld == null || !viewer.getWorld().getUID().equals(senderWorld)) {
+                        viewer.hideEntity(plugin, display);
+                        return;
+                    }
+                    boolean inRange = viewer.getLocation().distanceSquared(senderLoc) <= viewRangeSquared;
+                    boolean allowed = inRange && NametageCondition.evaluateAll(viewerConditions, viewer);
+                    if (allowed) viewer.showEntity(plugin, display);
+                    else viewer.hideEntity(plugin, display);
+                });
             }
-        }
+        });
     }
 
-    private boolean canViewerSee(Player sender, Player viewer) {
-        if (!sender.getWorld().equals(viewer.getWorld())) return false;
-        if (sender.getLocation().distanceSquared(viewer.getLocation()) > viewRangeSquared) return false;
-        return NametageCondition.evaluateAll(viewerConditions, viewer);
-    }
-
-    /**
-     * Keeps a TextDisplay entity positioned relative to its owner.
-     * xOffset / yOffsetTotal are in world units added to the player's location.
-     */
+    /** Keeps a TextDisplay positioned relative to its owner. */
     private void startPositionTracker(Player sender, TextDisplay display, double xOffset, double yOffsetTotal) {
         OreTask[] taskRef = {null};
+
+        // Keep the lifecycle timer attached to the display entity, but capture the owner's
+        // location on the owner's entity scheduler. On Folia, moving the display must use
+        // teleportAsync even when both entities happen to be in the same region.
         taskRef[0] = OreScheduler.runTimerForEntity(plugin, display, () -> {
-            if (!display.isValid() || !sender.isOnline()) {
+            if (!display.isValid()) {
+                if (taskRef[0] != null) taskRef[0].cancel();
+                return;
+            }
+            if (!sender.isOnline()) {
                 if (taskRef[0] != null) taskRef[0].cancel();
                 display.remove();
                 return;
             }
-            Location target = sender.getLocation().add(xOffset, yOffsetTotal, 0);
-            display.teleport(target);
+
+            OreScheduler.runForEntity(plugin, sender, () -> {
+                if (!sender.isOnline() || !display.isValid()) return;
+                Location target = sender.getLocation().clone().add(xOffset, yOffsetTotal, 0);
+                try {
+                    if (OreScheduler.isFolia()) {
+                        display.teleportAsync(target);
+                    } else {
+                        display.teleport(target);
+                    }
+                } catch (Throwable t) {
+                    if (taskRef[0] != null) taskRef[0].cancel();
+                    plugin.getLogger().fine("[ChatBubble] Position tracker stopped: " + t.getMessage());
+                }
+            });
         }, 2L, 2L);
     }
 
-    // ── Animations ────────────────────────────────────────────────────────────
-
-    /** Fades opacity from 0 to 127 over appearTicks ticks, then calls callback. */
     private void animateAppear(TextDisplay display, Runnable onDone) {
         animateOpacity(display, 0, 127, Math.max(1, appearTicks), onDone);
     }
 
-    /** Fades opacity from 127 to 0 over disappearTicks ticks, then calls callback. */
     private void animateDisappear(TextDisplay display, Runnable onDone) {
         animateOpacity(display, 127, 0, Math.max(1, disappearTicks), onDone);
     }
@@ -368,7 +362,7 @@ public final class ChatBubbleService implements Listener {
             if (step[0] >= totalTicks) {
                 display.setTextOpacity((byte) to);
                 if (taskRef[0] != null) taskRef[0].cancel();
-                if (onDone != null) OreScheduler.run(plugin, onDone);
+                if (onDone != null) OreScheduler.runForEntity(plugin, display, onDone);
             }
         }, 1L, 1L);
     }
@@ -385,8 +379,6 @@ public final class ChatBubbleService implements Listener {
             if (entity != null) OreScheduler.runForEntity(plugin, entity, entity::remove);
         }
     }
-
-    // ── Helpers ───────────────────────────────────────────────────────────────
 
     private String truncateToMaxLines(String message) {
         String[] words = message.split(" ");
@@ -405,25 +397,19 @@ public final class ChatBubbleService implements Listener {
         if (current.length() > 0 && lines.size() < maxLines) {
             lines.add(current.toString().trim());
         }
-
         return String.join("\n", lines);
     }
 
-    // ── Public API ────────────────────────────────────────────────────────────
-
     public boolean isEnabled() { return enabled; }
 
-    /** Sets a custom MiniMessage color tag for a player's bubbles (e.g. {@code "<red>"}). */
     public void setPlayerColor(UUID uuid, String colorTag) {
         playerBubbleColors.put(uuid, colorTag);
     }
 
-    /** Removes the player's custom bubble color, reverting to the server default. */
     public void clearPlayerColor(UUID uuid) {
         playerBubbleColors.remove(uuid);
     }
 
-    /** Returns the player's current bubble color tag, or {@code null} if using default. */
     public String getPlayerColor(UUID uuid) {
         return playerBubbleColors.get(uuid);
     }

--- a/src/main/java/fr/elias/oreoEssentials/modules/tp/command/TpCommand.java
+++ b/src/main/java/fr/elias/oreoEssentials/modules/tp/command/TpCommand.java
@@ -6,6 +6,7 @@ import fr.elias.oreoEssentials.playerdirectory.PlayerDirectory;
 import fr.elias.oreoEssentials.modules.tp.service.TeleportService;
 import fr.elias.oreoEssentials.modules.tp.rabbit.brokers.TpCrossServerBroker;
 import fr.elias.oreoEssentials.util.Lang;
+import fr.elias.oreoEssentials.util.OreScheduler;
 import org.bukkit.Bukkit;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
@@ -34,27 +35,23 @@ public class TpCommand implements OreoCommand {
         if (!(sender instanceof Player admin)) return true;
 
         if (args.length < 1) {
-            Lang.send(admin, "admin.tp.usage",
-                    "<red>Usage: /tp <player></red>");
+            Lang.send(admin, "admin.tp.usage", "<red>Usage: /tp <player></red>");
             return true;
         }
 
         String arg = args[0].trim();
         if (arg.isEmpty()) {
-            Lang.send(admin, "admin.tp.usage",
-                    "<red>Usage: /tp <player></red>");
+            Lang.send(admin, "admin.tp.usage", "<red>Usage: /tp <player></red>");
             return true;
         }
 
         OreoEssentials plugin = OreoEssentials.get();
         String localServer = plugin.getConfigService().serverName();
 
-        // 1) Try local online
         Player localTarget = resolveOnline(arg);
         if (localTarget != null) {
             if (localTarget.equals(admin)) {
-                Lang.send(admin, "admin.tp.self",
-                        "<red>You are already yourself.</red>");
+                Lang.send(admin, "admin.tp.self", "<red>You are already yourself.</red>");
                 return true;
             }
             teleportService.teleportSilently(admin, localTarget);
@@ -64,7 +61,6 @@ public class TpCommand implements OreoCommand {
             return true;
         }
 
-        // 2) Cross-server via PlayerDirectory
         PlayerDirectory dir = plugin.getPlayerDirectory();
         if (dir == null) {
             Lang.send(admin, "admin.tp.not-found-no-directory",
@@ -72,63 +68,67 @@ public class TpCommand implements OreoCommand {
             return true;
         }
 
-        UUID targetUuid = null;
-        try {
-            targetUuid = dir.lookupUuidByName(arg);
-        } catch (Throwable ignored) {}
-
-        if (targetUuid == null) {
+        // PlayerDirectory uses synchronous MongoDB. Resolve presence asynchronously and
+        // return to the admin's entity scheduler before touching Bukkit/player state again.
+        OreScheduler.runAsync(plugin, () -> {
+            UUID targetUuid = null;
+            String presence = null;
+            String targetName = arg;
             try {
-                targetUuid = UUID.fromString(arg);
-            } catch (Exception ignored) {}
-        }
-
-        if (targetUuid == null) {
-            Lang.send(admin, "admin.tp.not-found",
-                    "<red>Player not found online.</red>");
-            return true;
-        }
-
-        String presence = null;
-        try {
-            presence = dir.lookupCurrentServer(targetUuid);
-        } catch (Throwable ignored) {}
-
-        String targetName = safeNameLookup(dir, targetUuid, arg);
-
-        // If directory says: same server -> re-check just in case
-        if (presence != null && presence.equalsIgnoreCase(localServer)) {
-            Player again = Bukkit.getPlayer(targetUuid);
-            if (again != null && again.isOnline()) {
-                if (again.equals(admin)) {
-                    Lang.send(admin, "admin.tp.self",
-                            "<red>You are already yourself.</red>");
-                    return true;
+                targetUuid = dir.lookupUuidByName(arg);
+                if (targetUuid == null) {
+                    try { targetUuid = UUID.fromString(arg); } catch (Exception ignored) {}
                 }
-                teleportService.teleportSilently(admin, again);
-                Lang.send(admin, "admin.tp.teleported",
-                        "<green>Teleported to <aqua>%target%</aqua>.</green>",
-                        Map.of("target", again.getName()));
-                return true;
-            }
-        }
+                if (targetUuid != null) {
+                    presence = dir.lookupCurrentServer(targetUuid);
+                    String resolved = dir.lookupNameByUuid(targetUuid);
+                    if (resolved != null && !resolved.isBlank()) targetName = resolved;
+                }
+            } catch (Throwable ignored) {}
 
-        // 3) Remote server: use TpCrossServerBroker
-        if (presence != null && !presence.isBlank() && !presence.equalsIgnoreCase(localServer)) {
-            TpCrossServerBroker tpBroker = plugin.getTpBroker();
-            if (tpBroker == null) {
-                Lang.send(admin, "admin.tp.no-broker",
-                        "<red>Cross-server teleport broker not available; cannot /tp to other servers.</red>");
-                return true;
-            }
+            final UUID resolvedUuid = targetUuid;
+            final String resolvedPresence = presence;
+            final String resolvedName = targetName;
 
-            tpBroker.requestCrossServerTp(admin, targetUuid, targetName, presence);
-            return true;
-        }
+            OreScheduler.runForEntity(plugin, admin, () -> {
+                if (!admin.isOnline()) return;
 
-        // 4) Unknown presence
-        Lang.send(admin, "admin.tp.not-found",
-                "<red>Player not found online.</red>");
+                if (resolvedUuid == null) {
+                    Lang.send(admin, "admin.tp.not-found", "<red>Player not found online.</red>");
+                    return;
+                }
+
+                if (resolvedPresence != null && resolvedPresence.equalsIgnoreCase(localServer)) {
+                    Player again = Bukkit.getPlayer(resolvedUuid);
+                    if (again != null && again.isOnline()) {
+                        if (again.equals(admin)) {
+                            Lang.send(admin, "admin.tp.self", "<red>You are already yourself.</red>");
+                            return;
+                        }
+                        teleportService.teleportSilently(admin, again);
+                        Lang.send(admin, "admin.tp.teleported",
+                                "<green>Teleported to <aqua>%target%</aqua>.</green>",
+                                Map.of("target", again.getName()));
+                        return;
+                    }
+                }
+
+                if (resolvedPresence != null && !resolvedPresence.isBlank()
+                        && !resolvedPresence.equalsIgnoreCase(localServer)) {
+                    TpCrossServerBroker tpBroker = plugin.getTpBroker();
+                    if (tpBroker == null) {
+                        Lang.send(admin, "admin.tp.no-broker",
+                                "<red>Cross-server teleport broker not available; cannot /tp to other servers.</red>");
+                        return;
+                    }
+                    tpBroker.requestCrossServerTp(admin, resolvedUuid, resolvedName, resolvedPresence);
+                    return;
+                }
+
+                Lang.send(admin, "admin.tp.not-found", "<red>Player not found online.</red>");
+            });
+        });
+
         return true;
     }
 
@@ -148,14 +148,5 @@ public class TpCommand implements OreoCommand {
         } catch (Exception ignored) {}
 
         return null;
-    }
-
-    private String safeNameLookup(PlayerDirectory dir, UUID uuid, String fallback) {
-        try {
-            String n = dir.lookupNameByUuid(uuid);
-            return (n == null || n.isBlank()) ? fallback : n;
-        } catch (Throwable ignored) {
-            return fallback;
-        }
     }
 }

--- a/src/main/java/fr/elias/oreoEssentials/modules/tp/command/TpaCommand.java
+++ b/src/main/java/fr/elias/oreoEssentials/modules/tp/command/TpaCommand.java
@@ -3,11 +3,8 @@ package fr.elias.oreoEssentials.modules.tp.command;
 import fr.elias.oreoEssentials.OreoEssentials;
 import fr.elias.oreoEssentials.commands.OreoCommand;
 import fr.elias.oreoEssentials.modules.tp.service.TeleportService;
-import fr.elias.oreoEssentials.rabbitmq.PacketChannels;
-import fr.elias.oreoEssentials.rabbitmq.channel.PacketChannel;
-import fr.elias.oreoEssentials.rabbitmq.packet.PacketManager;
-import fr.elias.oreoEssentials.rabbitmq.packet.impl.SendRemoteMessagePacket;
 import fr.elias.oreoEssentials.util.Lang;
+import fr.elias.oreoEssentials.util.OreScheduler;
 import org.bukkit.Bukkit;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
@@ -38,8 +35,7 @@ public class TpaCommand implements OreoCommand {
     }
 
     private static String ms(long startNanos) {
-        long ms = (System.nanoTime() - startNanos) / 1_000_000L;
-        return ms + "ms";
+        return ((System.nanoTime() - startNanos) / 1_000_000L) + "ms";
     }
 
     private boolean dbg() {
@@ -79,8 +75,7 @@ public class TpaCommand implements OreoCommand {
 
         if (args.length < 1) {
             Lang.send(requester, "tpa.usage",
-                    "<red>Usage: /%label% <player></red>",
-                    Map.of("label", label));
+                    "<red>Usage: /%label% <player></red>", Map.of("label", label));
             return true;
         }
 
@@ -89,202 +84,138 @@ public class TpaCommand implements OreoCommand {
         final String input = args[0].trim();
         final OreoEssentials plugin = OreoEssentials.get();
         final String localServer = plugin.getConfigService().serverName();
-        final var broker = plugin.getTpaBroker();
 
         D(id, "enter by=" + requester.getName() + " input='" + input + "' server=" + localServer);
         P(requester, id, "start");
 
         if (input.isEmpty()) {
             Lang.send(requester, "tpa.usage",
-                    "<red>Usage: /%label% <player></red>",
-                    Map.of("label", label));
-            D(id, "empty input");
+                    "<red>Usage: /%label% <player></red>", Map.of("label", label));
             return true;
         }
 
-        // 1) Try local resolve (exact, UUID, display name)
-        long tLocal = System.nanoTime();
+        // Fast local path: no database involved.
         Player local = resolveOnline(input);
-        D(id, "localResolve=" + (local == null ? "null" : local.getName()) + " in " + ms(tLocal));
         if (local != null) {
             if (local.equals(requester)) {
-                Lang.send(requester, "tpa.self",
-                        "<red>You cannot TPA to yourself.</red>");
-                D(id, "self target");
+                Lang.send(requester, "tpa.self", "<red>You cannot TPA to yourself.</red>");
                 return true;
             }
-            // TeleportService.request() already sends the requester confirmation
-            // and target notification, so don't duplicate tpa.sent.local here.
-            teleportService.request(requester, local);
-
-            OreoEssentials pluginRef = OreoEssentials.get();
-            if (pluginRef.getDialogManager() != null) {
-                pluginRef.getDialogManager().sendTpaRequestDialog(local, requester, false);
-            }
-
+            queueLocalRequest(requester, local);
             D(id, "same-server request queued in " + ms(t0));
             P(requester, id, "same server ✓");
             return true;
         }
 
-        long tDir = System.nanoTime();
-        var dir = plugin.getPlayerDirectory();
+        final var dir = plugin.getPlayerDirectory();
         if (dir == null) {
-            D(id, "PlayerDirectory=null (Mongo storage not enabled?)");
             Lang.send(requester, "tpa.not-found.generic",
                     "<red>Player <white>%input%</white> not found online. <gray>(They may be offline or on another proxy cluster.)</gray></red>",
                     Map.of("input", input));
             return true;
         }
 
-        UUID targetUuid = null;
-        try {
-            targetUuid = dir.lookupUuidByName(input);
-            D(id, "lookupUuidByName -> " + targetUuid + " in " + ms(tDir));
-            P(requester, id, "directory " + (targetUuid != null ? "hit" : "miss"));
-        } catch (Throwable t) {
-            E(id, "directory lookup error", t);
-        }
+        // PlayerDirectory uses the synchronous Mongo driver. Never perform these lookups
+        // on the player's region thread.
+        OreScheduler.runAsync(plugin, () -> {
+            UUID targetUuid = null;
+            String where = null;
+            String shownName = input;
 
-        if (targetUuid == null) {
             try {
-                targetUuid = UUID.fromString(input);
-                D(id, "parsed UUID literal -> " + targetUuid);
-            } catch (Exception ignored) {
-                D(id, "not a UUID literal");
-            }
-        }
-
-        if (targetUuid == null) {
-            Lang.send(requester, "tpa.not-found.name-hint",
-                    "<red>Player <white>%input%</white> is not online. <gray>(If they're on another server, use their exact Minecraft name.)</gray></red>",
-                    Map.of("input", input));
-            D(id, "no UUID; exit in " + ms(t0));
-            return true;
-        }
-
-        long tPresence = System.nanoTime();
-        String where = null;
-        try {
-            where = dir.lookupCurrentServer(targetUuid);
-            D(id, "presence=" + where + " in " + ms(tPresence));
-            P(requester, id, "presence: " + (where == null ? "unknown" : where));
-        } catch (Throwable t) {
-            E(id, "presence lookup error", t);
-        }
-
-        if (where != null && where.equalsIgnoreCase(localServer)) {
-            long tUuid = System.nanoTime();
-            Player byId = Bukkit.getPlayer(targetUuid);
-            D(id, "sameServerPresence -> UUID-online=" + (byId != null) + " in " + ms(tUuid));
-            if (byId != null) {
-                if (byId.equals(requester)) {
-                    Lang.send(requester, "tpa.self",
-                            "<red>You cannot TPA to yourself.</red>");
-                    return true;
+                targetUuid = dir.lookupUuidByName(input);
+                if (targetUuid == null) {
+                    try { targetUuid = UUID.fromString(input); } catch (Exception ignored) {}
                 }
-                teleportService.request(requester, byId);
-                OreoEssentials pluginRef2 = OreoEssentials.get();
-                if (pluginRef2.getDialogManager() != null) {
-                    pluginRef2.getDialogManager().sendTpaRequestDialog(byId, requester, false);
+
+                if (targetUuid != null) {
+                    where = dir.lookupCurrentServer(targetUuid);
+                    String resolved = dir.lookupNameByUuid(targetUuid);
+                    if (resolved != null && !resolved.isBlank()) shownName = resolved;
                 }
-                D(id, "same-server via UUID ok in " + ms(t0));
-                P(requester, id, "same server (UUID) ✓");
-                return true;
-            }
-            D(id, "presence said same, but not online now (race?)");
-        }
-
-        if (where != null && !where.isBlank() && !where.equalsIgnoreCase(localServer)) {
-            String shownName = safeNameLookup(dir, targetUuid, input);
-
-            if (broker != null) {
-                broker.sendRequestToServer(requester, targetUuid, shownName, where);
-                Lang.send(requester, "tpa.sent.cross-server",
-                        "<gray>Request sent to <aqua>%target%</aqua> on <aqua>%server%</aqua>. They can </gray><green>/tpaccept</green><gray>.</gray>",
-                        Map.of("target", shownName, "server", where));
-                D(id, "cross-server -> request sent via broker to " + where + " (name=" + shownName + ")");
-            } else {
-                Lang.send(requester, "tpa.broker-unavailable",
-                        "<red>Cross-server TPA broker is currently unavailable. <gray>Ask </gray><white>%target%</white><gray> to join your server directly.</gray></red>",
-                        Map.of("target", shownName));
-                D(id, "cross-server -> broker null; cannot send request");
+            } catch (Throwable t) {
+                E(id, "directory lookup error", t);
             }
 
-            String pingMsg = Lang.msgWithDefault(
-                    "tpa.request-target",
-                    "<aqua>%player%</aqua> <yellow>wants to teleport to you.</yellow> <green>/tpaccept</green> <yellow>or</yellow> <red>/tpdeny</red> <yellow>(<white>%timeout%</white>s)</yellow>",
-                    Map.of("player", requester.getName(), "timeout", "30"),
-                    null
-            );
+            final UUID resolvedUuid = targetUuid;
+            final String resolvedWhere = where;
+            final String resolvedName = shownName;
 
-            tryPerServerPing(plugin, where, targetUuid, pingMsg, id);
-            D(id, "done in " + ms(t0));
-            return true;
-        }
+            OreScheduler.runForEntity(plugin, requester, () -> {
+                if (!requester.isOnline()) return;
 
-        if (where == null || where.isBlank()) {
-            D(id, "presence unknown -> attempting GLOBAL broker request + ping");
-            String shownName = safeNameLookup(dir, targetUuid, input);
+                if (resolvedUuid == null) {
+                    Lang.send(requester, "tpa.not-found.name-hint",
+                            "<red>Player <white>%input%</white> is not online. <gray>(If they're on another server, use their exact Minecraft name.)</gray></red>",
+                            Map.of("input", input));
+                    return;
+                }
 
-            if (broker != null) {
-                broker.sendRequestGlobal(requester, targetUuid, shownName);
-                P(requester, id, "broker global request ✓");
-            } else {
-                D(id, "broker null; cannot send global request");
-            }
+                if (resolvedWhere != null && resolvedWhere.equalsIgnoreCase(localServer)) {
+                    Player byId = Bukkit.getPlayer(resolvedUuid);
+                    if (byId != null && byId.isOnline()) {
+                        if (byId.equals(requester)) {
+                            Lang.send(requester, "tpa.self", "<red>You cannot TPA to yourself.</red>");
+                            return;
+                        }
+                        queueLocalRequest(requester, byId);
+                        D(id, "same-server via directory in " + ms(t0));
+                        return;
+                    }
+                }
 
-            String pingMsg = Lang.msgWithDefault(
-                    "tpa.request-target",
-                    "<aqua>%player%</aqua> <yellow>wants to teleport to you.</yellow> <green>/tpaccept</green> <yellow>or</yellow> <red>/tpdeny</red> <yellow>(<white>%timeout%</white>s)</yellow>",
-                    Map.of("player", requester.getName(), "timeout", "30"),
-                    null
-            );
+                var broker = plugin.getTpaBroker();
+                if (resolvedWhere != null && !resolvedWhere.isBlank()
+                        && !resolvedWhere.equalsIgnoreCase(localServer)) {
+                    if (broker == null) {
+                        Lang.send(requester, "tpa.broker-unavailable",
+                                "<red>Cross-server TPA broker is currently unavailable. <gray>Ask </gray><white>%target%</white><gray> to join your server directly.</gray></red>",
+                                Map.of("target", resolvedName));
+                        return;
+                    }
 
-            tryGlobalPing(plugin, targetUuid, pingMsg, id);
+                    // TpaCrossServerBroker is the single notification path. Do not also send a
+                    // SendRemoteMessagePacket here, otherwise the target receives the request twice.
+                    broker.sendRequestToServer(requester, resolvedUuid, resolvedName, resolvedWhere);
+                    Lang.send(requester, "tpa.sent.cross-server",
+                            "<gray>Request sent to <aqua>%target%</aqua> on <aqua>%server%</aqua>. They can </gray><green>/tpaccept</green><gray>.</gray>",
+                            Map.of("target", resolvedName, "server", resolvedWhere));
+                    D(id, "cross-server request sent in " + ms(t0));
+                    return;
+                }
 
-            Lang.send(requester, "tpa.sent.global",
-                    "<gray>We broadcast your request to <white>%target%</white> across the network. If they're online, they can </gray><green>/tpaccept</green><gray>.</gray>",
-                    Map.of("target", shownName));
-            D(id, "presence unknown -> GLOBAL request done in " + ms(t0));
-            return true;
-        }
+                if (broker != null) {
+                    broker.sendRequestGlobal(requester, resolvedUuid, resolvedName);
+                    Lang.send(requester, "tpa.sent.global",
+                            "<gray>We broadcast your request to <white>%target%</white> across the network. If they're online, they can </gray><green>/tpaccept</green><gray>.</gray>",
+                            Map.of("target", resolvedName));
+                } else {
+                    Lang.send(requester, "tpa.not-found.generic",
+                            "<red>Player <white>%input%</white> not found online. <gray>(They may be offline or on another proxy cluster.)</gray></red>",
+                            Map.of("input", input));
+                }
+                D(id, "directory path done in " + ms(t0));
+            });
+        });
 
-        long tUuid = System.nanoTime();
-        Player byId = Bukkit.getPlayer(targetUuid);
-        D(id, "lastChance UUID-online=" + (byId != null) + " in " + ms(tUuid));
-        if (byId != null) {
-            if (byId.equals(requester)) {
-                Lang.send(requester, "tpa.self",
-                        "<red>You cannot TPA to yourself.</red>");
-                return true;
-            }
-            teleportService.request(requester, byId);
-            OreoEssentials pluginRef3 = OreoEssentials.get();
-            if (pluginRef3.getDialogManager() != null) {
-                pluginRef3.getDialogManager().sendTpaRequestDialog(byId, requester, false);
-            }
-            D(id, "last-chance UUID accepted in " + ms(t0));
-            P(requester, id, "found (late) ✓");
-            return true;
-        }
-
-        Lang.send(requester, "tpa.not-found.generic",
-                "<red>Player <white>%input%</white> not found online. <gray>(They may be offline or on another proxy cluster.)</gray></red>",
-                Map.of("input", input));
-        D(id, "final not found in " + ms(t0));
         return true;
     }
 
+    private void queueLocalRequest(Player requester, Player target) {
+        teleportService.request(requester, target);
+        OreoEssentials plugin = OreoEssentials.get();
+        if (plugin.getDialogManager() != null) {
+            OreScheduler.runForEntity(plugin, target, () -> {
+                if (target.isOnline() && plugin.getDialogManager() != null) {
+                    plugin.getDialogManager().sendTpaRequestDialog(target, requester, false);
+                }
+            });
+        }
+    }
 
     private Player resolveOnline(String input) {
         Player p = Bukkit.getPlayerExact(input);
         if (p != null) return p;
-
-        final String want = input.toLowerCase(Locale.ROOT);
-        for (Player online : Bukkit.getOnlinePlayers()) {
-            if (online.getName().equalsIgnoreCase(want)) return online;
-        }
 
         try {
             UUID id = UUID.fromString(input);
@@ -293,6 +224,7 @@ public class TpaCommand implements OreoCommand {
         } catch (Exception ignored) {}
 
         for (Player online : Bukkit.getOnlinePlayers()) {
+            if (online.getName().equalsIgnoreCase(input)) return online;
             String dn = online.getDisplayName();
             if (dn != null) {
                 String stripped = org.bukkit.ChatColor.stripColor(dn);
@@ -300,62 +232,5 @@ public class TpaCommand implements OreoCommand {
             }
         }
         return null;
-    }
-
-    private String safeNameLookup(fr.elias.oreoEssentials.playerdirectory.PlayerDirectory dir,
-                                  UUID uuid, String fallback) {
-        try {
-            String n = dir.lookupNameByUuid(uuid);
-            return (n == null || n.isBlank()) ? fallback : n;
-        } catch (Throwable ignored) {
-            return fallback;
-        }
-    }
-
-    private boolean tryPerServerPing(OreoEssentials plugin, String serverName, UUID targetUuid, String msg, String id) {
-        long tPing = System.nanoTime();
-        PacketManager pm = plugin.getPacketManager();
-        if (pm == null) {
-            D(id, "PacketManager=null (Rabbit disabled?)");
-            return false;
-        }
-        if (!pm.isInitialized()) {
-            D(id, "PacketManager !initialized");
-            return false;
-        }
-
-        try {
-            var channel = PacketChannel.individual(serverName);
-            D(id, "PUBLISH channel=" + channel + " target=" + targetUuid);
-            pm.sendPacket(channel, new SendRemoteMessagePacket(targetUuid, msg));
-            D(id, "per-server ping -> server=" + serverName + " uuid=" + targetUuid + " in " + ms(tPing));
-            return true;
-        } catch (Throwable t) {
-            E(id, "per-server ping failed", t);
-            return false;
-        }
-    }
-
-    private boolean tryGlobalPing(OreoEssentials plugin, UUID targetUuid, String msg, String id) {
-        long tPing = System.nanoTime();
-        PacketManager pm = plugin.getPacketManager();
-        if (pm == null) {
-            D(id, "PacketManager=null (Rabbit disabled?)");
-            return false;
-        }
-        if (!pm.isInitialized()) {
-            D(id, "PacketManager !initialized");
-            return false;
-        }
-
-        try {
-            D(id, "PUBLISH channel=[global] target=" + targetUuid);
-            pm.sendPacket(PacketChannels.GLOBAL, new SendRemoteMessagePacket(targetUuid, msg));
-            D(id, "GLOBAL ping -> uuid=" + targetUuid + " in " + ms(tPing));
-            return true;
-        } catch (Throwable t) {
-            E(id, "GLOBAL ping failed", t);
-            return false;
-        }
     }
 }

--- a/src/main/java/fr/elias/oreoEssentials/modules/tp/service/TeleportService.java
+++ b/src/main/java/fr/elias/oreoEssentials/modules/tp/service/TeleportService.java
@@ -46,27 +46,35 @@ public class TeleportService implements Listener {
     public boolean request(Player from, Player to) {
         if (from == null || to == null || !from.isOnline() || !to.isOnline()) return false;
 
+        final UUID fromId = from.getUniqueId();
+        final UUID toId = to.getUniqueId();
+        final String fromName = from.getName();
+        final String toName = to.getName();
         long exp = System.currentTimeMillis() + timeoutSec * 1000L;
-        pendingToTarget.put(to.getUniqueId(), new TpaRequest(from.getUniqueId(), exp));
+        pendingToTarget.put(toId, new TpaRequest(fromId, exp));
 
-        // Notify target
-        Lang.send(
-                to,
-                "tpa.request-target",
-                "<yellow><bold>%player%</bold></yellow> <gray>wants to teleport to you.</gray> "
-                        + "<dark_gray>(expires in</dark_gray> <white>%timeout%</white><dark_gray>s)</dark_gray>",
-                Map.of(
-                        "player", from.getName(),
-                        "timeout", String.valueOf(timeoutSec)
-                )
-        );
+        // Each player is messaged on their own entity scheduler. This matters on Folia when
+        // requester and target are in different regions.
+        OreScheduler.runForEntity(plugin, to, () -> {
+            if (!to.isOnline()) return;
+            Lang.send(
+                    to,
+                    "tpa.request-target",
+                    "<yellow><bold>%player%</bold></yellow> <gray>wants to teleport to you.</gray> "
+                            + "<dark_gray>(expires in</dark_gray> <white>%timeout%</white><dark_gray>s)</dark_gray>",
+                    Map.of("player", fromName, "timeout", String.valueOf(timeoutSec))
+            );
+        });
 
-        Lang.send(
-                from,
-                "tpa.sent.local",
-                "<green>Teleport request sent to <yellow>%target%</yellow>.</green>",
-                Map.of("target", to.getName())
-        );
+        OreScheduler.runForEntity(plugin, from, () -> {
+            if (!from.isOnline()) return;
+            Lang.send(
+                    from,
+                    "tpa.sent.local",
+                    "<green>Teleport request sent to <yellow>%target%</yellow>.</green>",
+                    Map.of("target", toName)
+            );
+        });
         return true;
     }
 
@@ -77,54 +85,47 @@ public class TeleportService implements Listener {
         long now = System.currentTimeMillis();
 
         if (req == null || req.expiresAt < now) {
-            Lang.send(
-                    target,
-                    "tpa.accept.none",
-                    "<red>No pending teleport requests.</red>"
-            );
+            Lang.send(target, "tpa.accept.none", "<red>No pending teleport requests.</red>");
             return false;
         }
 
         Player from = Bukkit.getPlayer(req.from);
         if (from == null || !from.isOnline()) {
-            Lang.send(
-                    target,
-                    "tpa.accept.requester-offline",
-                    "<red>The requester is no longer online.</red>"
-            );
+            Lang.send(target, "tpa.accept.requester-offline", "<red>The requester is no longer online.</red>");
             return false;
         }
 
-        // record /back
-        try { if (back != null) back.setLast(from.getUniqueId(), from.getLocation()); } catch (Throwable ignored) {}
+        // accept() is invoked from the target's entity thread, so capture the destination here.
+        final Location dest = target.getLocation().clone();
+        final String targetName = target.getName();
+        final String requesterName = from.getName();
 
-        // do TP
-        Location dest = target.getLocation();
-        if (dest != null) {
-            OreScheduler.runForEntity(plugin, from, () -> {
+        OreScheduler.runForEntity(plugin, from, () -> {
+            if (!from.isOnline()) return;
+            try { if (back != null) back.setLast(from.getUniqueId(), from.getLocation()); } catch (Throwable ignored) {}
+
+            try {
                 if (OreScheduler.isFolia()) {
                     from.teleportAsync(dest);
                 } else {
                     from.teleport(dest);
                 }
-            });
-        }
+            } catch (Throwable ignored) {}
 
-        // messages
-        Lang.send(
-                from,
-                "tpa.teleported",
-                "<green>Teleported to <yellow>%target%</yellow>.</green>",
-                Map.of("target", target.getName())
-        );
+            Lang.send(
+                    from,
+                    "tpa.teleported",
+                    "<green>Teleported to <yellow>%target%</yellow>.</green>",
+                    Map.of("target", targetName)
+            );
+        });
 
         Lang.send(
                 target,
                 "tpa.accept.accepted",
                 "<green>Accepted teleport request from <yellow>%player%</yellow>.</green>",
-                Map.of("player", from.getName())
+                Map.of("player", requesterName)
         );
-
         return true;
     }
 
@@ -133,29 +134,25 @@ public class TeleportService implements Listener {
 
         TpaRequest req = pendingToTarget.remove(target.getUniqueId());
         if (req == null) {
-            Lang.send(
-                    target,
-                    "tpa.accept.none",
-                    "<red>No pending teleport requests.</red>"
-            );
+            Lang.send(target, "tpa.accept.none", "<red>No pending teleport requests.</red>");
             return false;
         }
 
+        final String targetName = target.getName();
         Player from = Bukkit.getPlayer(req.from);
         if (from != null && from.isOnline()) {
-            Lang.send(
-                    from,
-                    "tpa.deny.requester",
-                    "<red>Your teleport request to <yellow>%target%</yellow> was denied.</red>",
-                    Map.of("target", target.getName())
-            );
+            OreScheduler.runForEntity(plugin, from, () -> {
+                if (!from.isOnline()) return;
+                Lang.send(
+                        from,
+                        "tpa.deny.requester",
+                        "<red>Your teleport request to <yellow>%target%</yellow> was denied.</red>",
+                        Map.of("target", targetName)
+                );
+            });
         }
 
-        Lang.send(
-                target,
-                "tpa.deny.target",
-                "<yellow>Denied the teleport request.</yellow>"
-        );
+        Lang.send(target, "tpa.deny.target", "<yellow>Denied the teleport request.</yellow>");
         return true;
     }
 
@@ -167,23 +164,22 @@ public class TeleportService implements Listener {
     @EventHandler
     public void onQuit(PlayerQuitEvent event) {
         UUID uuid = event.getPlayer().getUniqueId();
-        // Remove any pending request where this player is the target
         pendingToTarget.remove(uuid);
-        // Remove any pending requests where this player is the sender
         pendingToTarget.entrySet().removeIf(e -> e.getValue().from.equals(uuid));
     }
 
-
     public void teleportSilently(Player who, Location to) {
         if (who == null || to == null) return;
-        try { if (back != null) back.setLast(who.getUniqueId(), who.getLocation()); } catch (Throwable ignored) {}
+        final Location destination = to.clone();
 
         OreScheduler.runForEntity(plugin, who, () -> {
+            if (!who.isOnline()) return;
+            try { if (back != null) back.setLast(who.getUniqueId(), who.getLocation()); } catch (Throwable ignored) {}
             try {
                 if (OreScheduler.isFolia()) {
-                    who.teleportAsync(to);
+                    who.teleportAsync(destination);
                 } else {
-                    who.teleport(to);
+                    who.teleport(destination);
                 }
             } catch (Throwable ignored) {}
         });
@@ -191,7 +187,12 @@ public class TeleportService implements Listener {
 
     public void teleportSilently(Player who, Player target) {
         if (who == null || target == null || !target.isOnline()) return;
-        teleportSilently(who, target.getLocation());
+        // Read the target's location on the target's owning region, then hand the immutable
+        // Location snapshot to the requester's entity scheduler.
+        OreScheduler.runForEntity(plugin, target, () -> {
+            if (!target.isOnline()) return;
+            teleportSilently(who, target.getLocation().clone());
+        });
     }
 
     public Player getRequester(Player target) {
@@ -206,41 +207,36 @@ public class TeleportService implements Listener {
         TpaRequest req = pendingToTarget.remove(target.getUniqueId());
         if (req == null) return false;
 
+        final String requesterName = requester != null ? requester.getName() : "unknown";
         if (requester != null && requester.isOnline()) {
-            Lang.send(
-                    requester,
-                    "tpa.cancelled-moved-requester",
-                    "<red>Your teleport request was cancelled because you moved.</red>"
-            );
+            Lang.send(requester, "tpa.cancelled-moved-requester",
+                    "<red>Your teleport request was cancelled because you moved.</red>");
         }
 
         if (target.isOnline()) {
-            String name = requester != null ? requester.getName() : "unknown";
-            Lang.send(
-                    target,
-                    "tpa.cancelled-moved-target",
-                    "<yellow>Teleport request from <white>%requester%</white> was cancelled (requester moved).</yellow>",
-                    Map.of("requester", name)
-            );
+            OreScheduler.runForEntity(plugin, target, () -> {
+                if (!target.isOnline()) return;
+                Lang.send(
+                        target,
+                        "tpa.cancelled-moved-target",
+                        "<yellow>Teleport request from <white>%requester%</white> was cancelled (requester moved).</yellow>",
+                        Map.of("requester", requesterName)
+                );
+            });
         }
-
         return true;
     }
-
 
     public boolean teleportToServerLocation(Player who, BackLocation loc) {
         if (who == null || loc == null) return false;
 
         String localServer = plugin.getConfigService().serverName();
-
-        // same server → local tp
         if (loc.getServer() == null
                 || loc.getServer().isBlank()
                 || loc.getServer().equalsIgnoreCase(localServer)) {
 
             Location dest = loc.toLocalLocation();
             if (dest == null) return false;
-
             teleportSilently(who, dest);
             return true;
         }
@@ -250,7 +246,6 @@ public class TeleportService implements Listener {
             backBroker.requestCrossServerBack(who, loc);
             return true;
         }
-
         return false;
     }
 

--- a/src/main/java/fr/elias/oreoEssentials/playersync/PlayerSyncListener.java
+++ b/src/main/java/fr/elias/oreoEssentials/playersync/PlayerSyncListener.java
@@ -3,10 +3,14 @@ package fr.elias.oreoEssentials.playersync;
 import fr.elias.oreoEssentials.OreoEssentials;
 import fr.elias.oreoEssentials.util.OreScheduler;
 import org.bukkit.Bukkit;
-import org.bukkit.event.*;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerJoinEvent;
 import org.bukkit.event.player.PlayerQuitEvent;
-import org.bukkit.entity.Player;
+
+import java.util.UUID;
 
 public final class PlayerSyncListener implements Listener {
     private final PlayerSyncService service;
@@ -20,30 +24,52 @@ public final class PlayerSyncListener implements Listener {
     @EventHandler(priority = EventPriority.MONITOR)
     public void onQuit(PlayerQuitEvent e) {
         if (!enabled) return;
-        // BUG-16: Save on async thread — YAML I/O must not block the main thread.
+
         final Player quitting = e.getPlayer();
-        OreScheduler.runAsync(OreoEssentials.get(), () -> service.saveIfEnabled(quitting));
+        final UUID uuid = quitting.getUniqueId();
+
+        // Read Bukkit player state while we still own the player's region/thread,
+        // then perform only serialization/storage work asynchronously.
+        final PlayerSyncSnapshot snapshot;
+        try {
+            snapshot = service.captureSnapshot(quitting);
+        } catch (Throwable t) {
+            OreoEssentials.get().getLogger().warning("[SYNC] capture failed for " + uuid + ": " + t.getMessage());
+            return;
+        }
+
+        OreScheduler.runAsync(OreoEssentials.get(), () -> service.saveSnapshot(uuid, snapshot));
     }
 
     @EventHandler(priority = EventPriority.MONITOR)
     public void onJoin(PlayerJoinEvent e) {
         if (!enabled) return;
-        Player p = e.getPlayer();
+        final Player p = e.getPlayer();
+        final UUID uuid = p.getUniqueId();
+        final String name = p.getName();
 
-        try {
-            OreoEssentials.get().getPlayerDirectory().saveMapping(p.getName(), p.getUniqueId());
-        } catch (Exception ex) {
-        }
+        // PlayerDirectory uses the synchronous Mongo driver, so never query/write it on a region thread.
+        OreScheduler.runAsync(OreoEssentials.get(), () -> {
+            try {
+                var directory = OreoEssentials.get().getPlayerDirectory();
+                if (directory != null) directory.saveMapping(name, uuid);
+            } catch (Throwable ignored) {}
+        });
 
-        OreScheduler.runLaterForEntity(
-                OreoEssentials.get(),
-                p,
-                () -> {
-                    Player online = Bukkit.getPlayer(p.getUniqueId());
-                    if (online == null || !online.isOnline()) return; // player disconnected during delay
-                    service.loadAndApply(online);
-                },
-                10L
-        );
+        // Preserve the original 10-tick join grace period, but move the storage load off-thread.
+        OreScheduler.runLaterForEntity(OreoEssentials.get(), p, () -> {
+            if (!p.isOnline()) return;
+
+            OreScheduler.runAsync(OreoEssentials.get(), () -> {
+                PlayerSyncSnapshot snapshot = service.loadSnapshot(uuid);
+                if (snapshot == null) return;
+
+                OreScheduler.runForEntity(OreoEssentials.get(), p, () -> {
+                    Player online = Bukkit.getPlayer(uuid);
+                    if (online == null || !online.isOnline()) return;
+                    service.applySnapshot(online, snapshot);
+                });
+            });
+        }, 10L);
     }
 }

--- a/src/main/java/fr/elias/oreoEssentials/playersync/PlayerSyncPrefsStore.java
+++ b/src/main/java/fr/elias/oreoEssentials/playersync/PlayerSyncPrefsStore.java
@@ -24,10 +24,11 @@ public final class PlayerSyncPrefsStore {
         this.cfg  = YamlConfiguration.loadConfiguration(file);
     }
 
+    /**
+     * Returns the cached preferences without touching disk.
+     * Disk I/O belongs off the server/region thread; call reload() explicitly when needed.
+     */
     public synchronized PlayerSyncPrefs get(UUID id) {
-        try {
-            cfg.load(file); // reload from disk to avoid stale in-memory cache
-        } catch (Exception ignored) {}
         String base = "prefs." + id + ".";
         if (!cfg.contains(base)) return PlayerSyncPrefs.defaults(dInv, dXp, dHealth, dHunger, dPotions);
         PlayerSyncPrefs p = new PlayerSyncPrefs();
@@ -47,5 +48,9 @@ public final class PlayerSyncPrefsStore {
         cfg.set(base + "hunger",  p.hunger);
         cfg.set(base + "potions", p.potions);
         try { cfg.save(file); } catch (Exception ignored) {}
+    }
+
+    public synchronized void reload() {
+        this.cfg = YamlConfiguration.loadConfiguration(file);
     }
 }

--- a/src/main/java/fr/elias/oreoEssentials/playersync/PlayerSyncService.java
+++ b/src/main/java/fr/elias/oreoEssentials/playersync/PlayerSyncService.java
@@ -12,6 +12,7 @@ import org.bukkit.potion.PotionEffectType;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.UUID;
 
 public final class PlayerSyncService {
     private final OreoEssentials plugin;
@@ -24,66 +25,64 @@ public final class PlayerSyncService {
         this.prefs = prefs;
     }
 
-    public void saveIfEnabled(Player p) {
+    /** Capture Bukkit player state. Must run on the player's owning thread/region. */
+    public PlayerSyncSnapshot captureSnapshot(Player p) {
+        PlayerSyncPrefs pr = prefs.get(p.getUniqueId());
+        PlayerSyncSnapshot s = new PlayerSyncSnapshot();
+
+        if (pr.inv) {
+            s.inventory = p.getInventory().getContents();
+            s.armor     = p.getInventory().getArmorContents();
+            s.offhand   = p.getInventory().getItemInOffHand();
+        } else {
+            s.inventory = new ItemStack[0];
+            s.armor     = new ItemStack[0];
+            s.offhand   = null;
+        }
+
+        if (pr.xp) {
+            s.level = Math.max(0, p.getLevel());
+            s.exp   = Math.max(0f, Math.min(1f, p.getExp()));
+        } else {
+            s.level = 0;
+            s.exp   = 0f;
+        }
+
+        s.health = Math.max(0.0, p.getHealth());
+        s.food = Math.max(0, Math.min(20, p.getFoodLevel()));
+        s.saturation = Math.max(0f, Math.min(20f, p.getSaturation()));
+        s.potionData = pr.potions ? serializePotions(p.getActivePotionEffects()) : null;
+        return s;
+    }
+
+    /** Storage-only operation; safe to run asynchronously. */
+    public void saveSnapshot(UUID uuid, PlayerSyncSnapshot snapshot) {
         try {
-            PlayerSyncPrefs pr = prefs.get(p.getUniqueId());
-            PlayerSyncSnapshot s = new PlayerSyncSnapshot();
-
-            if (pr.inv) {
-                s.inventory = p.getInventory().getContents();
-                s.armor     = p.getInventory().getArmorContents();
-                s.offhand   = p.getInventory().getItemInOffHand();
-            } else {
-                s.inventory = new ItemStack[0];
-                s.armor     = new ItemStack[0];
-                s.offhand   = null;
-            }
-
-            if (pr.xp) {
-                s.level = Math.max(0, p.getLevel());
-                s.exp   = Math.max(0f, Math.min(1f, p.getExp()));
-            } else {
-                s.level = 0;
-                s.exp   = 0f;
-            }
-
-            if (pr.health) {
-                s.health = Math.max(0.0, p.getHealth());
-            } else {
-                s.health = p.getHealth();
-            }
-
-            if (pr.hunger) {
-                s.food       = Math.max(0, Math.min(20, p.getFoodLevel()));
-                s.saturation = Math.max(0f, Math.min(20f, p.getSaturation()));
-            } else {
-                s.food       = p.getFoodLevel();
-                s.saturation = p.getSaturation();
-            }
-
-            if (pr.potions) {
-                s.potionData = serializePotions(p.getActivePotionEffects());
-            } else {
-                s.potionData = null;
-            }
-
-            storage.save(p.getUniqueId(), s);
+            storage.save(uuid, snapshot);
         } catch (Throwable t) {
-            plugin.getLogger().warning("[SYNC] save failed for " + p.getUniqueId() + ": " + t.getMessage());
+            plugin.getLogger().warning("[SYNC] save failed for " + uuid + ": " + t.getMessage());
         }
     }
 
-    public void loadAndApply(Player p) {
+    /** Storage-only operation; safe to run asynchronously. */
+    public PlayerSyncSnapshot loadSnapshot(UUID uuid) {
         try {
-            if (!p.isOnline()) return; // guard: player may have disconnected before load completes
+            return storage.load(uuid);
+        } catch (Throwable t) {
+            plugin.getLogger().warning("[SYNC] load failed for " + uuid + ": " + t.getMessage());
+            return null;
+        }
+    }
+
+    /** Apply a previously loaded snapshot. Must run on the player's owning thread/region. */
+    public void applySnapshot(Player p, PlayerSyncSnapshot s) {
+        try {
+            if (p == null || s == null || !p.isOnline()) return;
             PlayerSyncPrefs pr = prefs.get(p.getUniqueId());
-            PlayerSyncSnapshot s = storage.load(p.getUniqueId());
-            if (s == null) return;
-            if (!p.isOnline()) return; // guard: player may have disconnected during async load
 
             if (pr.inv) {
                 if (s.inventory != null) {
-                    ItemStack[] main = EnderChestStorage.clamp(s.inventory, 4); // 4 rows = 36 slots
+                    ItemStack[] main = EnderChestStorage.clamp(s.inventory, 4);
                     p.getInventory().setContents(main);
                 }
                 if (s.armor != null) {
@@ -92,7 +91,6 @@ public final class PlayerSyncService {
                 p.getInventory().setItemInOffHand(s.offhand);
             }
 
-            // XP
             if (pr.xp) {
                 p.setLevel(Math.max(0, s.level));
                 p.setExp(Math.max(0f, Math.min(1f, s.exp)));
@@ -101,16 +99,8 @@ public final class PlayerSyncService {
             if (pr.health) {
                 AttributeInstance maxHealthAttr = p.getAttribute(Attribute.MAX_HEALTH);
                 double max = (maxHealthAttr != null ? maxHealthAttr.getValue() : 20.0);
-
                 double raw = s.health;
-                double target;
-
-                if (raw <= 0.0) {
-                    target = max;
-                } else {
-                    target = Math.max(1.0, Math.min(max, raw));
-                }
-
+                double target = raw <= 0.0 ? max : Math.max(1.0, Math.min(max, raw));
                 try {
                     p.setHealth(target);
                 } catch (IllegalArgumentException ignored) {
@@ -118,11 +108,9 @@ public final class PlayerSyncService {
                 }
             }
 
-            // Hunger
             if (pr.hunger) {
                 int food = s.food;
                 float sat = s.saturation;
-
                 if (food <= 0 && sat <= 0f) {
                     p.setFoodLevel(20);
                     p.setSaturation(10f);
@@ -132,7 +120,6 @@ public final class PlayerSyncService {
                 }
             }
 
-            // Potions
             if (pr.potions && s.potionData != null && !s.potionData.isEmpty()) {
                 List<PotionEffect> effects = deserializePotions(s.potionData);
                 for (PotionEffect active : p.getActivePotionEffects()) {
@@ -143,7 +130,7 @@ public final class PlayerSyncService {
                 }
             }
         } catch (Throwable t) {
-            plugin.getLogger().warning("[SYNC] load/apply failed for " + p.getUniqueId() + ": " + t.getMessage());
+            plugin.getLogger().warning("[SYNC] apply failed for " + (p != null ? p.getUniqueId() : "unknown") + ": " + t.getMessage());
         }
     }
 


### PR DESCRIPTION
Fixes the stability issues identified in the audit:

- move PlayerSync Bukkit reads/writes to entity threads and storage I/O off-thread
- stop reloading player-sync preferences from disk on tick threads
- move /tpa and /tp PlayerDirectory lookups off region threads
- deduplicate cross-server TPA target notifications
- make local TPA/teleport operations Folia region-safe
- include the Folia-safe chat bubble tracker changes

This branch intentionally does not touch CommandManager.