### PR TITLE
Fix remaining Folia threading and stability issues

### DIFF
--- a/src/main/java/fr/elias/oreoEssentials/commands/core/playercommands/BottomCommand.java
+++ b/src/main/java/fr/elias/oreoEssentials/commands/core/playercommands/BottomCommand.java
@@ -1,7 +1,9 @@
 package fr.elias.oreoEssentials.commands.core.playercommands;
 
+import fr.elias.oreoEssentials.OreoEssentials;
 import fr.elias.oreoEssentials.commands.OreoCommand;
 import fr.elias.oreoEssentials.util.Lang;
+import fr.elias.oreoEssentials.util.OreScheduler;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.World;
@@ -12,30 +14,11 @@ import java.util.List;
 
 public class BottomCommand implements OreoCommand {
 
-    @Override
-    public String name() {
-        return "bottom";
-    }
-
-    @Override
-    public List<String> aliases() {
-        return List.of();
-    }
-
-    @Override
-    public String permission() {
-        return "oreo.bottom";
-    }
-
-    @Override
-    public String usage() {
-        return "";
-    }
-
-    @Override
-    public boolean playerOnly() {
-        return true;
-    }
+    @Override public String name() { return "bottom"; }
+    @Override public List<String> aliases() { return List.of(); }
+    @Override public String permission() { return "oreo.bottom"; }
+    @Override public String usage() { return ""; }
+    @Override public boolean playerOnly() { return true; }
 
     @Override
     public boolean execute(CommandSender sender, String label, String[] args) {
@@ -47,14 +30,12 @@ public class BottomCommand implements OreoCommand {
         int z = loc.getBlockZ();
         int minY = world.getMinHeight();
 
-        // Find the lowest solid, non-air block scanning upward from bedrock
         int floorY = -1;
         for (int y = minY; y < world.getMaxHeight() - 1; y++) {
             Material type = world.getBlockAt(x, y, z).getType();
             if (!type.isAir() && type != Material.WATER && type != Material.LAVA
                     && type != Material.KELP && type != Material.KELP_PLANT
                     && type != Material.SEAGRASS && type != Material.TALL_SEAGRASS) {
-                // Make sure there are two air blocks above to stand in
                 Material above1 = world.getBlockAt(x, y + 1, z).getType();
                 Material above2 = world.getBlockAt(x, y + 2, z).getType();
                 if (above1.isAir() && above2.isAir()) {
@@ -70,8 +51,22 @@ public class BottomCommand implements OreoCommand {
         }
 
         Location dest = new Location(world, x + 0.5, floorY + 1, z + 0.5, loc.getYaw(), loc.getPitch());
-        p.teleport(dest);
-        Lang.send(p, "bottom.teleported", "<green>Teleported to the bottom.</green>");
+        if (OreScheduler.isFolia()) {
+            p.teleportAsync(dest).whenComplete((ok, err) ->
+                    OreScheduler.runForEntity(OreoEssentials.get(), p, () -> {
+                        if (err == null && Boolean.TRUE.equals(ok)) {
+                            Lang.send(p, "bottom.teleported", "<green>Teleported to the bottom.</green>");
+                        } else {
+                            Lang.send(p, "bottom.failed", "<red>Teleport failed.</red>");
+                        }
+                    }));
+        } else {
+            if (p.teleport(dest)) {
+                Lang.send(p, "bottom.teleported", "<green>Teleported to the bottom.</green>");
+            } else {
+                Lang.send(p, "bottom.failed", "<red>Teleport failed.</red>");
+            }
+        }
         return true;
     }
 }

--- a/src/main/java/fr/elias/oreoEssentials/commands/core/playercommands/TopCommand.java
+++ b/src/main/java/fr/elias/oreoEssentials/commands/core/playercommands/TopCommand.java
@@ -1,7 +1,9 @@
 package fr.elias.oreoEssentials.commands.core.playercommands;
 
+import fr.elias.oreoEssentials.OreoEssentials;
 import fr.elias.oreoEssentials.commands.OreoCommand;
 import fr.elias.oreoEssentials.util.Lang;
+import fr.elias.oreoEssentials.util.OreScheduler;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.World;
@@ -12,30 +14,11 @@ import java.util.List;
 
 public class TopCommand implements OreoCommand {
 
-    @Override
-    public String name() {
-        return "top";
-    }
-
-    @Override
-    public List<String> aliases() {
-        return List.of();
-    }
-
-    @Override
-    public String permission() {
-        return "oreo.top";
-    }
-
-    @Override
-    public String usage() {
-        return "";
-    }
-
-    @Override
-    public boolean playerOnly() {
-        return true;
-    }
+    @Override public String name() { return "top"; }
+    @Override public List<String> aliases() { return List.of(); }
+    @Override public String permission() { return "oreo.top"; }
+    @Override public String usage() { return ""; }
+    @Override public boolean playerOnly() { return true; }
 
     @Override
     public boolean execute(CommandSender sender, String label, String[] args) {
@@ -47,7 +30,6 @@ public class TopCommand implements OreoCommand {
         int z = loc.getBlockZ();
         int maxY = world.getMaxHeight() - 1;
 
-        // Find the highest non-air, non-liquid solid block from the top down
         int surfaceY = -1;
         for (int y = maxY; y >= world.getMinHeight(); y--) {
             Material type = world.getBlockAt(x, y, z).getType();
@@ -64,10 +46,23 @@ public class TopCommand implements OreoCommand {
             return true;
         }
 
-        // Teleport to one block above the surface block, keeping yaw/pitch
         Location dest = new Location(world, x + 0.5, surfaceY + 1, z + 0.5, loc.getYaw(), loc.getPitch());
-        p.teleport(dest);
-        Lang.send(p, "top.teleported", "<green>Teleported to the surface.</green>");
+        if (OreScheduler.isFolia()) {
+            p.teleportAsync(dest).whenComplete((ok, err) ->
+                    OreScheduler.runForEntity(OreoEssentials.get(), p, () -> {
+                        if (err == null && Boolean.TRUE.equals(ok)) {
+                            Lang.send(p, "top.teleported", "<green>Teleported to the surface.</green>");
+                        } else {
+                            Lang.send(p, "top.failed", "<red>Teleport failed.</red>");
+                        }
+                    }));
+        } else {
+            if (p.teleport(dest)) {
+                Lang.send(p, "top.teleported", "<green>Teleported to the surface.</green>");
+            } else {
+                Lang.send(p, "top.failed", "<red>Teleport failed.</red>");
+            }
+        }
         return true;
     }
 }

--- a/src/main/java/fr/elias/oreoEssentials/modgui/freeze/FreezeManager.java
+++ b/src/main/java/fr/elias/oreoEssentials/modgui/freeze/FreezeManager.java
@@ -1,13 +1,13 @@
-// File: src/main/java/fr/elias/oreoEssentials/modgui/freeze/FreezeManager.java
 package fr.elias.oreoEssentials.modgui.freeze;
 
 import fr.elias.oreoEssentials.OreoEssentials;
 import fr.elias.oreoEssentials.util.Lang;
 import fr.elias.oreoEssentials.util.OreScheduler;
+import fr.elias.oreoEssentials.util.OreTask;
 import org.bukkit.Bukkit;
+import org.bukkit.Particle;
 import org.bukkit.entity.Player;
 
-import java.util.Iterator;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
@@ -17,21 +17,20 @@ public class FreezeManager {
     public static class FreezeData {
         public final UUID target;
         public final UUID staff;
-        public final long until; // millis
+        public final long until;
 
         public FreezeData(UUID target, UUID staff, long until) {
             this.target = target;
-            this.staff  = staff;
-            this.until  = until;
+            this.staff = staff;
+            this.until = until;
         }
 
-        public long remainingMillis() {
-            return until - System.currentTimeMillis();
-        }
+        public long remainingMillis() { return until - System.currentTimeMillis(); }
     }
 
     private final OreoEssentials plugin;
     private final Map<UUID, FreezeData> frozen = new ConcurrentHashMap<>();
+    private OreTask tickTask;
 
     public FreezeManager(OreoEssentials plugin) {
         this.plugin = plugin;
@@ -42,7 +41,7 @@ public class FreezeManager {
         FreezeData data = frozen.get(id);
         if (data == null) return false;
         if (data.remainingMillis() <= 0) {
-            frozen.remove(id);
+            frozen.remove(id, data);
             return false;
         }
         return true;
@@ -52,80 +51,71 @@ public class FreezeManager {
 
     public void freeze(Player target, Player staff, long seconds) {
         long until = System.currentTimeMillis() + (seconds * 1000L);
-        frozen.put(
-                target.getUniqueId(),
-                new FreezeData(
-                        target.getUniqueId(),
-                        staff == null ? null : staff.getUniqueId(),
-                        until
-                )
-        );
-
-        // why: correct Lang.send signature and MiniMessage default
-        Lang.send(
-                target,
-                "freeze.frozen",
+        frozen.put(target.getUniqueId(), new FreezeData(
+                target.getUniqueId(), staff == null ? null : staff.getUniqueId(), until));
+        Lang.send(target, "freeze.frozen",
                 "<red>You are frozen for <yellow>%seconds%</yellow>s.</red>",
-                Map.of("seconds", Long.toString(seconds))
-        );
+                Map.of("seconds", Long.toString(seconds)));
     }
 
     public void unfreeze(Player target) {
         frozen.remove(target.getUniqueId());
+        Lang.send(target, "freeze.unfrozen", "<green>You are no longer frozen.</green>");
+    }
 
-        // why: provide default; vars not needed
-        Lang.send(
-                target,
-                "freeze.unfrozen",
-                "<green>You are no longer frozen.</green>"
-        );
+    public void shutdown() {
+        if (tickTask != null) {
+            tickTask.cancel();
+            tickTask = null;
+        }
+        frozen.clear();
     }
 
     private void startTickTask() {
-        OreScheduler.runTimer(plugin, () -> {
-            long now = System.currentTimeMillis();
-
-            for (Iterator<Map.Entry<UUID, FreezeData>> it = frozen.entrySet().iterator(); it.hasNext();) {
-                Map.Entry<UUID, FreezeData> e = it.next();
-                FreezeData data = e.getValue();
+        tickTask = OreScheduler.runTimer(plugin, () -> {
+            final long now = System.currentTimeMillis();
+            for (Map.Entry<UUID, FreezeData> entry : frozen.entrySet()) {
+                UUID targetId = entry.getKey();
+                FreezeData data = entry.getValue();
 
                 if (data.until <= now) {
-                    Player t = Bukkit.getPlayer(e.getKey());
-                    if (t != null) {
-                        Lang.send(
-                                t,
-                                "freeze.expired",
-                                "<yellow>Your freeze has expired.</yellow>"
-                        );
+                    if (!frozen.remove(targetId, data)) continue;
+                    Player target = Bukkit.getPlayer(targetId);
+                    if (target != null) {
+                        OreScheduler.runForEntity(plugin, target, () -> {
+                            if (target.isOnline()) {
+                                Lang.send(target, "freeze.expired", "<yellow>Your freeze has expired.</yellow>");
+                            }
+                        });
                     }
-                    it.remove();
                     continue;
                 }
 
-                Player t = Bukkit.getPlayer(e.getKey());
-                if (t == null) continue;
+                Player target = Bukkit.getPlayer(targetId);
+                if (target == null) continue;
 
-                // particle (visual feedback)
-                t.getWorld().spawnParticle(
-                        org.bukkit.Particle.SNOWFLAKE,
-                        t.getLocation().add(0, 0.1, 0),
-                        6, 0.3, 0.1, 0.3, 0.01
-                );
+                OreScheduler.runForEntity(plugin, target, () -> {
+                    if (!target.isOnline() || frozen.get(targetId) != data) return;
 
-                // staff actionbar with remaining seconds (Adventure)
-                long remSeconds = data.remainingMillis() / 1000L;
-                if (data.staff != null) {
-                    Player s = Bukkit.getPlayer(data.staff);
-                    if (s != null && s.isOnline()) {
-                        s.sendActionBar(
-                                Lang.msgComp(
-                                        "freeze.actionbar-staff",
-                                        Map.of("target", t.getName(), "seconds", Long.toString(remSeconds)),
-                                        s
-                                )
-                        );
-                    }
-                }
+                    target.getWorld().spawnParticle(
+                            Particle.SNOWFLAKE,
+                            target.getLocation().add(0, 0.1, 0),
+                            6, 0.3, 0.1, 0.3, 0.01);
+
+                    if (data.staff == null) return;
+                    String targetName = target.getName();
+                    long remSeconds = Math.max(0L, data.remainingMillis() / 1000L);
+                    Player staff = Bukkit.getPlayer(data.staff);
+                    if (staff == null) return;
+
+                    OreScheduler.runForEntity(plugin, staff, () -> {
+                        if (!staff.isOnline()) return;
+                        staff.sendActionBar(Lang.msgComp(
+                                "freeze.actionbar-staff",
+                                Map.of("target", targetName, "seconds", Long.toString(remSeconds)),
+                                staff));
+                    });
+                });
             }
         }, 10L, 10L);
     }

--- a/src/main/java/fr/elias/oreoEssentials/modules/clearlag/ClearLagManager.java
+++ b/src/main/java/fr/elias/oreoEssentials/modules/clearlag/ClearLagManager.java
@@ -3,21 +3,28 @@ package fr.elias.oreoEssentials.modules.clearlag;
 import fr.elias.oreoEssentials.OreoEssentials;
 import fr.elias.oreoEssentials.modules.clearlag.config.ClearLagConfig;
 import fr.elias.oreoEssentials.modules.clearlag.logic.EntityMatcher;
+import fr.elias.oreoEssentials.util.OreScheduler;
+import fr.elias.oreoEssentials.util.OreTask;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.minimessage.MiniMessage;
 import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
+import org.bukkit.Location;
 import org.bukkit.World;
 import org.bukkit.command.CommandSender;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.configuration.file.YamlConfiguration;
 import org.bukkit.entity.*;
-import fr.elias.oreoEssentials.util.OreScheduler;
-import fr.elias.oreoEssentials.util.OreTask;
 
 import java.io.File;
 import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
+import java.util.function.Predicate;
 
 public class ClearLagManager {
 
@@ -38,13 +45,15 @@ public class ClearLagManager {
 
     public void reload() {
         File file = new File(plugin.getDataFolder(), "server/clearlag.yml");
-        if (!file.exists()) { file.getParentFile().mkdirs(); plugin.saveResource("server/clearlag.yml", false); }
+        if (!file.exists()) {
+            file.getParentFile().mkdirs();
+            plugin.saveResource("server/clearlag.yml", false);
+        }
         FileConfiguration root = YamlConfiguration.loadConfiguration(file);
-
         this.cfg = new ClearLagConfig(root);
 
+        cancelSchedulers();
         if (!cfg.masterEnabled) {
-            cancelSchedulers();
             plugin.getLogger().info("[OreoLag] Disabled by config (enable=false).");
             return;
         }
@@ -53,41 +62,39 @@ public class ClearLagManager {
         restartSchedulers();
     }
 
+    public void shutdown() {
+        cancelSchedulers();
+    }
+
     private void cancelSchedulers() {
-        if (autoTask != null) {
-            autoTask.cancel();
-            autoTask = null;
-        }
-        if (autoKillMobsTask != null) {
-            autoKillMobsTask.cancel();
-            autoKillMobsTask = null;
-        }
-        if (tpsTask != null) {
-            tpsTask.cancel();
-            tpsTask = null;
-        }
+        if (autoTask != null) { autoTask.cancel(); autoTask = null; }
+        if (autoKillMobsTask != null) { autoKillMobsTask.cancel(); autoKillMobsTask = null; }
+        if (tpsTask != null) { tpsTask.cancel(); tpsTask = null; }
+        if (tpsSampleTask != null) { tpsSampleTask.cancel(); tpsSampleTask = null; }
+        tpsSamplerStarted = false;
     }
 
     private void restartSchedulers() {
-        if (autoTask != null) autoTask.cancel();
-        if (autoKillMobsTask != null) autoKillMobsTask.cancel();
-        if (tpsTask != null) tpsTask.cancel();
-
         if (cfg.auto.enabled) {
             int[] autoTick = {0};
             autoTask = OreScheduler.runTimer(plugin, () -> {
                 autoTick[0] += 20;
                 int remaining = (int) (cfg.auto.intervalSec - (autoTick[0] / 20));
                 cfg.auto.warnings.forEach(w -> {
-                    if (remaining == w.time()) {
-                        String msg = w.msg().replace("+remaining", String.valueOf(remaining));
-                        broadcast(msg);
-                    }
+                    if (remaining == w.time()) broadcast(w.msg().replace("+remaining", String.valueOf(remaining)));
                 });
                 if (remaining <= 0) {
-                    int removed = performRemoval(cfg.auto, true, null);
-                    if (cfg.auto.broadcastRemoval) {
-                        broadcast(cfg.auto.broadcastMsg.replace("+RemoveAmount", String.valueOf(removed)));
+                    if (OreScheduler.isFolia()) {
+                        performRemovalFolia(cfg.auto, removed -> {
+                            if (cfg.auto.broadcastRemoval) {
+                                broadcast(cfg.auto.broadcastMsg.replace("+RemoveAmount", String.valueOf(removed)));
+                            }
+                        });
+                    } else {
+                        int removed = performRemovalPaper(cfg.auto);
+                        if (cfg.auto.broadcastRemoval) {
+                            broadcast(cfg.auto.broadcastMsg.replace("+RemoveAmount", String.valueOf(removed)));
+                        }
                     }
                     autoTick[0] = 0;
                 }
@@ -100,15 +107,20 @@ public class ClearLagManager {
                 killTick[0] += 20;
                 int remaining = (int) (cfg.autoKillMobs.intervalSec() - (killTick[0] / 20));
                 cfg.autoKillMobs.warnings().forEach(w -> {
-                    if (remaining == w.time()) {
-                        String msg = w.msg().replace("+remaining", String.valueOf(remaining));
-                        broadcast(msg);
-                    }
+                    if (remaining == w.time()) broadcast(w.msg().replace("+remaining", String.valueOf(remaining)));
                 });
                 if (remaining <= 0) {
-                    int removed = performAutoKillMobs();
-                    if (cfg.autoKillMobs.broadcastRemoval()) {
-                        broadcast(cfg.autoKillMobs.broadcastMsg().replace("+RemoveAmount", String.valueOf(removed)));
+                    if (OreScheduler.isFolia()) {
+                        killMobsFolia(cfg.autoKillMobs, removed -> {
+                            if (cfg.autoKillMobs.broadcastRemoval()) {
+                                broadcast(cfg.autoKillMobs.broadcastMsg().replace("+RemoveAmount", String.valueOf(removed)));
+                            }
+                        });
+                    } else {
+                        int removed = killMobsPaper(cfg.autoKillMobs);
+                        if (cfg.autoKillMobs.broadcastRemoval()) {
+                            broadcast(cfg.autoKillMobs.broadcastMsg().replace("+RemoveAmount", String.valueOf(removed)));
+                        }
                     }
                     killTick[0] = 0;
                 }
@@ -116,15 +128,15 @@ public class ClearLagManager {
         }
 
         if (cfg.tps.enabled) {
-            boolean[] tpsTriggered = {false};
+            boolean[] triggered = {false};
             tpsTask = OreScheduler.runTimer(plugin, () -> {
                 double tps = getServerTPS();
-                if (!tpsTriggered[0] && tps <= cfg.tps.trigger) {
-                    tpsTriggered[0] = true;
+                if (!triggered[0] && tps <= cfg.tps.trigger) {
+                    triggered[0] = true;
                     if (cfg.tps.broadcastEnabled) broadcast(cfg.tps.triggerMsg);
                     runCommands(cfg.tps.commands);
-                } else if (tpsTriggered[0] && tps >= cfg.tps.recover) {
-                    tpsTriggered[0] = false;
+                } else if (triggered[0] && tps >= cfg.tps.recover) {
+                    triggered[0] = false;
                     if (cfg.tps.broadcastEnabled) broadcast(cfg.tps.recoverMsg);
                     runCommands(cfg.tps.recoverCommands);
                 }
@@ -135,15 +147,13 @@ public class ClearLagManager {
     private void startTpsSampler() {
         if (tpsSamplerStarted) return;
         tpsSamplerStarted = true;
-
+        lastTickNanos = System.nanoTime();
         tpsSampleTask = OreScheduler.runTimer(plugin, () -> {
             long now = System.nanoTime();
             long dt = now - lastTickNanos;
             lastTickNanos = now;
-
             if (dt <= 0) return;
-            double instTps = 1_000_000_000.0 / dt;
-            if (instTps > 25.0) instTps = 25.0;
+            double instTps = Math.min(25.0, 1_000_000_000.0 / dt);
             rollingTps = (rollingTps * 0.9) + (Math.min(20.0, instTps) * 0.1);
         }, 1L, 1L);
     }
@@ -155,112 +165,158 @@ public class ClearLagManager {
 
     public int commandClear(CommandSender sender) {
         if (!cfg.masterEnabled) {
-            sender.sendMessage("§c[OreoLag] Disabled by config.");
+            send(sender, "§c[OreoLag] Disabled by config.");
             return 0;
         }
-        int removed = performRemoval(cfg.cmd, false, sender);
-        if (!cfg.cmd.broadcastRemoval) {
-            sender.sendMessage("§a[OreoLag] Removed §e" + removed + " §aentities.");
+        if (OreScheduler.isFolia()) {
+            send(sender, "§e[OreoLag] Cleanup scheduled across loaded player regions...");
+            performRemovalFolia(cfg.cmd, removed -> send(sender,
+                    "§a[OreoLag] Removed §e" + removed + " §aentities."));
+            return 0;
         }
+        int removed = performRemovalPaper(cfg.cmd);
+        if (!cfg.cmd.broadcastRemoval) send(sender, "§a[OreoLag] Removed §e" + removed + " §aentities.");
         return removed;
     }
 
     public int commandKillMobs(CommandSender sender) {
         if (!cfg.masterEnabled) {
-            sender.sendMessage("§c[OreoLag] Disabled by config.");
+            send(sender, "§c[OreoLag] Disabled by config.");
             return 0;
         }
-        int removed = killMobs(cfg.killMobs);
-        sender.sendMessage("§a[OreoLag] Removed §e" + removed + " §amobs.");
+        if (OreScheduler.isFolia()) {
+            send(sender, "§e[OreoLag] Mob cleanup scheduled across loaded player regions...");
+            killMobsFolia(cfg.killMobs, removed -> send(sender,
+                    "§a[OreoLag] Removed §e" + removed + " §amobs."));
+            return 0;
+        }
+        int removed = killMobsPaper(cfg.killMobs);
+        send(sender, "§a[OreoLag] Removed §e" + removed + " §amobs.");
         return removed;
     }
 
     public void reloadAndAck(CommandSender sender) {
         reload();
-        sender.sendMessage("§a[OreoLag] Reloaded clearlag.yml and restarted tasks.");
+        send(sender, "§a[OreoLag] Reloaded clearlag.yml and restarted tasks.");
     }
 
-    private int performAutoKillMobs() {
-        return killMobs(cfg.autoKillMobs);
-    }
-
-    private int killMobs(ClearLagConfig.KillMobs config) {
+    private int killMobsPaper(ClearLagConfig.KillMobs config) {
         int removed = 0;
         for (World world : Bukkit.getWorlds()) {
-            if (world == null) continue;
-            if (config.worldFilter().contains(world.getName())) continue;
-
+            if (world == null || config.worldFilter().contains(world.getName())) continue;
             for (LivingEntity le : world.getEntitiesByClass(LivingEntity.class)) {
                 if (le instanceof Player) continue;
-
                 if (!config.removeNamed() && hasCustomName(le)) continue;
                 if (EntityMatcher.isFilteredMob(le, config.mobFilter())) continue;
-
-                removeEntitySafe(le);
+                le.remove();
                 removed++;
             }
         }
         return removed;
     }
 
-    private int performRemoval(ClearLagConfig.Removal r, boolean scheduled, CommandSender issuer) {
-        if (!cfg.masterEnabled) return 0;
+    private int performRemovalPaper(ClearLagConfig.Removal r) {
         int removed = 0;
         for (World w : Bukkit.getWorlds()) {
-            if (w == null) continue;
-            if (r.worldFilter.contains(w.getName())) continue;
-
+            if (w == null || r.worldFilter.contains(w.getName())) continue;
             for (Entity e : w.getEntities()) {
                 if (e instanceof Player) continue;
-
-                if (!allowedByFlags(e, r)) continue;
-                if (EntityMatcher.inAreaFilter(e, cfg.areaFilter)) continue;
-                if (EntityMatcher.matchesTokens(e, r.removeEntities)) {
-                    removeEntitySafe(e);
-                    removed++;
-                    continue;
-                }
-
-                if (e instanceof Item it) {
-                    if (!r.flagItem) continue;
-                    if (OreScheduler.isFolia()) {
-                        // On Folia, getItemStack() must run on the entity's region thread.
-                        // Dispatch the whitelist check + removal there; count is approximate.
-                        it.getScheduler().run(plugin, ctx -> {
-                            if (!r.itemWhitelist.contains(it.getItemStack().getType())) it.remove();
-                        }, null);
-                        removed++;
-                    } else {
-                        if (r.itemWhitelist.contains(it.getItemStack().getType())) continue;
-                        removeEntitySafe(it);
-                        removed++;
-                    }
-                    continue;
-                }
-
-                if (isDirectlyRemovableByFlags(e, r)) {
-                    removeEntitySafe(e);
+                if (shouldRemove(e, r)) {
+                    e.remove();
                     removed++;
                 }
             }
         }
-        if (issuer != null && scheduled && r.broadcastRemoval) {
-            broadcast(r.broadcastMsg.replace("+RemoveAmount", String.valueOf(removed)));
-        }
         return removed;
     }
 
-    /**
-     * Removes an entity safely on both Paper and Folia.
-     * On Folia, entity.remove() must run on the entity's own region thread;
-     * calling it from the global scheduler thread crashes with a thread-check error.
-     */
-    private void removeEntitySafe(Entity entity) {
-        if (OreScheduler.isFolia()) {
-            entity.getScheduler().run(plugin, ctx -> entity.remove(), null);
-        } else {
-            entity.remove();
+    private boolean shouldRemove(Entity e, ClearLagConfig.Removal r) {
+        if (!allowedByFlags(e, r)) return false;
+        if (EntityMatcher.inAreaFilter(e, cfg.areaFilter)) return false;
+        if (EntityMatcher.matchesTokens(e, r.removeEntities)) return true;
+        if (e instanceof Item it) {
+            return r.flagItem && !r.itemWhitelist.contains(it.getItemStack().getType());
         }
+        return isDirectlyRemovableByFlags(e, r);
+    }
+
+    private void killMobsFolia(ClearLagConfig.KillMobs config, Consumer<Integer> callback) {
+        scanLoadedPlayerRegions(entity -> {
+            if (!(entity instanceof LivingEntity le) || le instanceof Player) return false;
+            if (config.worldFilter().contains(le.getWorld().getName())) return false;
+            if (!config.removeNamed() && hasCustomName(le)) return false;
+            return !EntityMatcher.isFilteredMob(le, config.mobFilter());
+        }, callback);
+    }
+
+    private void performRemovalFolia(ClearLagConfig.Removal r, Consumer<Integer> callback) {
+        scanLoadedPlayerRegions(entity -> {
+            if (entity instanceof Player) return false;
+            if (r.worldFilter.contains(entity.getWorld().getName())) return false;
+            return shouldRemove(entity, r);
+        }, callback);
+    }
+
+    /**
+     * Folia-safe cleanup: discover loaded chunks from each player's region and then inspect
+     * each chunk on that chunk's owning region scheduler. This avoids World#getEntities()
+     * and World#getEntitiesByClass() from the global region thread.
+     */
+    private void scanLoadedPlayerRegions(Predicate<Entity> removePredicate, Consumer<Integer> callback) {
+        Set<String> scheduledChunks = ConcurrentHashMap.newKeySet();
+        AtomicInteger pending = new AtomicInteger(1);
+        AtomicInteger removed = new AtomicInteger();
+        int radius = Math.max(2, Bukkit.getViewDistance() + 1);
+
+        Runnable completeOne = () -> {
+            if (pending.decrementAndGet() == 0) {
+                OreScheduler.run(plugin, () -> callback.accept(removed.get()));
+            }
+        };
+
+        for (Player player : Bukkit.getOnlinePlayers()) {
+            pending.incrementAndGet();
+            OreScheduler.runForEntity(plugin, player, () -> {
+                try {
+                    if (!player.isOnline()) return;
+                    Location loc = player.getLocation();
+                    World world = loc.getWorld();
+                    if (world == null) return;
+                    int centerX = loc.getBlockX() >> 4;
+                    int centerZ = loc.getBlockZ() >> 4;
+
+                    for (int dx = -radius; dx <= radius; dx++) {
+                        for (int dz = -radius; dz <= radius; dz++) {
+                            int cx = centerX + dx;
+                            int cz = centerZ + dz;
+                            String key = world.getUID() + ":" + cx + ":" + cz;
+                            if (!scheduledChunks.add(key)) continue;
+
+                            pending.incrementAndGet();
+                            Location anchor = new Location(world, (cx << 4) + 8, world.getMinHeight(), (cz << 4) + 8);
+                            OreScheduler.runAtLocation(plugin, anchor, () -> {
+                                try {
+                                    if (!world.isChunkLoaded(cx, cz)) return;
+                                    for (Entity entity : world.getChunkAt(cx, cz).getEntities()) {
+                                        try {
+                                            if (removePredicate.test(entity)) {
+                                                entity.remove();
+                                                removed.incrementAndGet();
+                                            }
+                                        } catch (Throwable ignored) {}
+                                    }
+                                } finally {
+                                    completeOne.run();
+                                }
+                            });
+                        }
+                    }
+                } finally {
+                    completeOne.run();
+                }
+            });
+        }
+        completeOne.run();
     }
 
     private boolean allowedByFlags(Entity e, ClearLagConfig.Removal r) {
@@ -300,31 +356,33 @@ public class ClearLagManager {
     private static final LegacyComponentSerializer LEGACY = LegacyComponentSerializer.legacySection();
 
     private void broadcast(String message) {
-        if (!cfg.masterEnabled) return;
-        if (!cfg.broadcast.enabled()) return;
+        if (!cfg.masterEnabled || !cfg.broadcast.enabled()) return;
         Component component = parseMessage(message);
-        if (cfg.broadcast.usePerm()) {
-            for (Player p : Bukkit.getOnlinePlayers()) {
-                if (p.hasPermission(cfg.broadcast.perm())) {
+        for (Player p : Bukkit.getOnlinePlayers()) {
+            OreScheduler.runForEntity(plugin, p, () -> {
+                if (!p.isOnline()) return;
+                if (!cfg.broadcast.usePerm() || p.hasPermission(cfg.broadcast.perm())) {
                     p.sendMessage(component);
                 }
-            }
+            });
+        }
+    }
+
+    private void send(CommandSender sender, String message) {
+        if (sender instanceof Player p) {
+            OreScheduler.runForEntity(plugin, p, () -> {
+                if (p.isOnline()) p.sendMessage(message);
+            });
         } else {
-            Bukkit.getServer().broadcast(component);
+            sender.sendMessage(message);
         }
     }
 
     private static Component parseMessage(String message) {
         if (message == null || message.isEmpty()) return Component.empty();
-        // Convert &#RRGGBB hex codes to MiniMessage <#RRGGBB>
-        message = message.replaceAll("&#([A-Fa-f0-9]{6})", "<#$1>");
-        // Convert legacy § codes to & so MiniMessage can handle them
-        message = message.replace('§', '&');
-        // If MiniMessage tags are present, use MM parser; otherwise fall back to legacy
+        message = message.replaceAll("&#([A-Fa-f0-9]{6})", "<#$1>").replace('§', '&');
         if (message.contains("<") && message.contains(">")) {
-            try {
-                return MM.deserialize(message);
-            } catch (Throwable ignored) {}
+            try { return MM.deserialize(message); } catch (Throwable ignored) {}
         }
         return LEGACY.deserialize(ChatColor.translateAlternateColorCodes('&', message));
     }
@@ -333,15 +391,10 @@ public class ClearLagManager {
         try {
             java.lang.reflect.Method m = Bukkit.getServer().getClass().getMethod("getTPS");
             Object res = m.invoke(Bukkit.getServer());
-            if (res instanceof double[] arr && arr.length > 0) {
-                return Math.min(20.0, arr[0]);
-            }
-        } catch (Throwable ignored) {
-        }
+            if (res instanceof double[] arr && arr.length > 0) return Math.min(20.0, arr[0]);
+        } catch (Throwable ignored) {}
         return rollingTps > 0 ? rollingTps : 20.0;
     }
 
-    public ClearLagConfig getConfigModel() {
-        return cfg;
-    }
+    public ClearLagConfig getConfigModel() { return cfg; }
 }

--- a/src/main/java/fr/elias/oreoEssentials/modules/jail/JailService.java
+++ b/src/main/java/fr/elias/oreoEssentials/modules/jail/JailService.java
@@ -10,19 +10,19 @@ import org.bukkit.entity.Player;
 import org.bukkit.plugin.Plugin;
 
 import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
 
 public final class JailService {
     private final Plugin plugin;
     private final JailStorage storage;
 
-    private final Map<String, JailModels.Jail> jails = new HashMap<>();
-    private final Map<UUID, JailModels.Sentence> active = new HashMap<>();
+    private final Map<String, JailModels.Jail> jails = new ConcurrentHashMap<>();
+    private final Map<UUID, JailModels.Sentence> active = new ConcurrentHashMap<>();
     private OreTask guardTask;
 
-    private final Set<String> blockedCommands = new HashSet<>(Arrays.asList(
+    private final Set<String> blockedCommands = Set.of(
             "spawn", "home", "sethome", "warp", "rtp", "tpa", "tp", "back",
-            "tpahere", "tpaccept", "wild", "randomtp"
-    ));
+            "tpahere", "tpaccept", "wild", "randomtp");
 
     public JailService(Plugin plugin, JailStorage storage) {
         this.plugin = plugin;
@@ -41,22 +41,14 @@ public final class JailService {
     }
 
     public void disable() {
-        try {
-            storage.saveJails(jails);
-        } catch (Throwable ignored) {}
-
-        try {
-            storage.saveSentences(active);
-        } catch (Throwable ignored) {}
-
         if (guardTask != null) {
             guardTask.cancel();
             guardTask = null;
         }
-
+        try { storage.saveJails(new HashMap<>(jails)); } catch (Throwable ignored) {}
+        try { storage.saveSentences(new HashMap<>(active)); } catch (Throwable ignored) {}
         storage.close();
     }
-
 
     public boolean createOrUpdateJail(String name, JailModels.Cuboid region, String world) {
         name = name.toLowerCase(Locale.ROOT);
@@ -65,78 +57,41 @@ public final class JailService {
         j.world = world;
         j.region = region;
         jails.put(name, j);
-
-        try {
-            storage.saveJail(j);
-        } catch (UnsupportedOperationException e) {
-            // Fallback to bulk save for YAML
-            storage.saveJails(jails);
-        }
-
+        try { storage.saveJail(j); }
+        catch (UnsupportedOperationException e) { storage.saveJails(new HashMap<>(jails)); }
         return true;
     }
 
     public boolean addCell(String jailName, String cellId, Location loc) {
         JailModels.Jail j = jails.get(jailName.toLowerCase(Locale.ROOT));
         if (j == null) return false;
-
         j.cells.put(cellId, loc.clone());
-
-        try {
-            storage.saveJail(j);
-        } catch (UnsupportedOperationException e) {
-            // Fallback to bulk save for YAML
-            storage.saveJails(jails);
-        }
-
+        try { storage.saveJail(j); }
+        catch (UnsupportedOperationException e) { storage.saveJails(new HashMap<>(jails)); }
         return true;
     }
 
     public boolean deleteJail(String name) {
         name = name.toLowerCase(Locale.ROOT);
         JailModels.Jail removed = jails.remove(name);
-
-        if (removed != null) {
-            try {
-                storage.deleteJail(name);
-            } catch (UnsupportedOperationException e) {
-                storage.saveJails(jails);
-            }
-            return true;
-        }
-
-        return false;
+        if (removed == null) return false;
+        try { storage.deleteJail(name); }
+        catch (UnsupportedOperationException e) { storage.saveJails(new HashMap<>(jails)); }
+        return true;
     }
 
-    public Map<String, JailModels.Jail> allJails() {
-        return Collections.unmodifiableMap(jails);
-    }
+    public Map<String, JailModels.Jail> allJails() { return Collections.unmodifiableMap(jails); }
+    public JailModels.Jail getJail(String name) { return jails.get(name.toLowerCase(Locale.ROOT)); }
 
-    public JailModels.Jail getJail(String name) {
-        return jails.get(name.toLowerCase(Locale.ROOT));
-    }
-
-
-    /**
-     * Jail a player (works even if they're offline).
-     * They will be teleported on next login if offline.
-     */
     public boolean jail(UUID player, String jailName, String cellId,
                         long durationMs, String reason, String by) {
         jailName = jailName.toLowerCase(Locale.ROOT);
         JailModels.Jail j = jails.get(jailName);
+        if (j == null || !j.isValid()) return false;
 
-        if (j == null || !j.isValid()) {
-            return false;
-        }
-
-        Location spawn = (cellId != null ? j.cells.get(cellId) : null);
-        if (spawn == null && !j.cells.isEmpty()) {
-            spawn = j.cells.values().iterator().next();
-        }
-        if (spawn == null) {
-            return false;
-        }
+        Location spawn = cellId != null ? j.cells.get(cellId) : null;
+        if (spawn == null && !j.cells.isEmpty()) spawn = j.cells.values().iterator().next();
+        if (spawn == null) return false;
 
         JailModels.Sentence s = new JailModels.Sentence();
         s.player = player;
@@ -144,27 +99,21 @@ public final class JailService {
         s.cellId = cellId;
         s.reason = reason == null ? "" : reason;
         s.by = by == null ? "console" : by;
-        s.endEpochMs = durationMs <= 0 ? 0 : (System.currentTimeMillis() + durationMs);
-
+        s.endEpochMs = durationMs <= 0 ? 0 : System.currentTimeMillis() + durationMs;
         active.put(player, s);
 
-        try {
-            storage.saveSentence(s);
-        } catch (UnsupportedOperationException e) {
-            storage.saveSentences(active);
-        }
+        try { storage.saveSentence(s); }
+        catch (UnsupportedOperationException e) { storage.saveSentences(new HashMap<>(active)); }
 
         Player p = Bukkit.getPlayer(player);
-        if (p != null && p.isOnline()) {
-            final Location finalSpawn = spawn;
+        if (p != null) {
+            Location finalSpawn = spawn.clone();
             OreScheduler.runForEntity(plugin, p, () -> {
-                if (OreScheduler.isFolia()) {
-                    p.teleportAsync(finalSpawn);
-                } else {
-                    p.teleport(finalSpawn);
-                }
+                if (!p.isOnline()) return;
+                if (OreScheduler.isFolia()) p.teleportAsync(finalSpawn);
+                else p.teleport(finalSpawn);
                 p.sendMessage("§cYou have been jailed"
-                        + (s.endEpochMs > 0 ? (" for " + TimeText.format(durationMs)) : " permanently")
+                        + (s.endEpochMs > 0 ? " for " + TimeText.format(durationMs) : " permanently")
                         + (s.reason.isBlank() ? "" : " §7Reason: §f" + s.reason));
             });
         }
@@ -173,191 +122,138 @@ public final class JailService {
             if (plugin instanceof OreoEssentials oe) {
                 var d = oe.getDiscordMod();
                 if (d != null && d.isEnabled()) {
-                    String name = String.valueOf(Bukkit.getOfflinePlayer(player).getName());
-                    d.notifyJail(name, player, j.name, cellId, s.reason, s.by, s.endEpochMs);
+                    String playerName = String.valueOf(Bukkit.getOfflinePlayer(player).getName());
+                    d.notifyJail(playerName, player, j.name, cellId, s.reason, s.by, s.endEpochMs);
                 }
             }
         } catch (Throwable ignored) {}
-
         return true;
     }
 
     public boolean release(UUID player) {
         JailModels.Sentence s = active.remove(player);
-
-        if (s != null) {
-            try {
-                storage.deleteSentence(player);
-            } catch (UnsupportedOperationException e) {
-                storage.saveSentences(active);
-            }
-
-            Player p = Bukkit.getPlayer(player);
-            if (p != null && p.isOnline()) {
-                p.sendMessage("§aYou have been released from jail.");
-            }
-
-            try {
-                if (plugin instanceof OreoEssentials oe) {
-                    var d = oe.getDiscordMod();
-                    if (d != null && d.isEnabled()) {
-                        String name = String.valueOf(Bukkit.getOfflinePlayer(player).getName());
-                        d.notifyUnjail(name, player, s.by == null || s.by.isBlank() ? "system" : s.by);
-                    }
-                }
-            } catch (Throwable ignored) {}
-
-            return true;
-        }
-
-        return false;
-    }
-
-    /**
-     * Extend a player's jail sentence.
-     * @return true if extended successfully
-     */
-    public boolean extendSentence(UUID player, long additionalMs, String by) {
-        JailModels.Sentence s = active.get(player);
         if (s == null) return false;
 
-        if (s.endEpochMs > 0) {
-            s.endEpochMs += additionalMs;
-        } else {
-            s.endEpochMs = System.currentTimeMillis() + additionalMs;
-        }
-
-        s.by = by == null ? "console" : by;
-
-        try {
-            storage.saveSentence(s);
-        } catch (UnsupportedOperationException e) {
-            storage.saveSentences(active);
-        }
+        try { storage.deleteSentence(player); }
+        catch (UnsupportedOperationException e) { storage.saveSentences(new HashMap<>(active)); }
 
         Player p = Bukkit.getPlayer(player);
-        if (p != null && p.isOnline()) {
-            p.sendMessage("§cYour sentence has been extended by " + TimeText.format(additionalMs));
+        if (p != null) {
+            OreScheduler.runForEntity(plugin, p, () -> {
+                if (p.isOnline()) p.sendMessage("§aYou have been released from jail.");
+            });
         }
 
+        try {
+            if (plugin instanceof OreoEssentials oe) {
+                var d = oe.getDiscordMod();
+                if (d != null && d.isEnabled()) {
+                    String playerName = String.valueOf(Bukkit.getOfflinePlayer(player).getName());
+                    d.notifyUnjail(playerName, player, s.by == null || s.by.isBlank() ? "system" : s.by);
+                }
+            }
+        } catch (Throwable ignored) {}
         return true;
     }
 
-    public JailModels.Sentence sentence(UUID u) {
-        return active.get(u);
+    public boolean extendSentence(UUID player, long additionalMs, String by) {
+        JailModels.Sentence s = active.get(player);
+        if (s == null) return false;
+        synchronized (s) {
+            s.endEpochMs = s.endEpochMs > 0 ? s.endEpochMs + additionalMs : System.currentTimeMillis() + additionalMs;
+            s.by = by == null ? "console" : by;
+        }
+        try { storage.saveSentence(s); }
+        catch (UnsupportedOperationException e) { storage.saveSentences(new HashMap<>(active)); }
+
+        Player p = Bukkit.getPlayer(player);
+        if (p != null) {
+            OreScheduler.runForEntity(plugin, p, () -> {
+                if (p.isOnline()) p.sendMessage("§cYour sentence has been extended by " + TimeText.format(additionalMs));
+            });
+        }
+        return true;
     }
 
-    public boolean isJailed(UUID player) {
-        return active.containsKey(player);
-    }
-
+    public JailModels.Sentence sentence(UUID u) { return active.get(u); }
+    public boolean isJailed(UUID player) { return active.containsKey(player); }
 
     private void tick() {
-        boolean changed = false;
+        long now = System.currentTimeMillis();
 
-        Iterator<Map.Entry<UUID, JailModels.Sentence>> it = active.entrySet().iterator();
-        while (it.hasNext()) {
-            Map.Entry<UUID, JailModels.Sentence> e = it.next();
-            if (e.getValue().expired()) {
-                UUID playerId = e.getKey();
+        for (Map.Entry<UUID, JailModels.Sentence> entry : active.entrySet()) {
+            UUID playerId = entry.getKey();
+            JailModels.Sentence sentence = entry.getValue();
+
+            if (sentence.expired()) {
+                if (!active.remove(playerId, sentence)) continue;
                 Player p = Bukkit.getPlayer(playerId);
-
-                if (p != null && p.isOnline()) {
-                    p.sendMessage("§aYour jail time is over.");
-                }
-
-                it.remove();
-
-                try {
-                    storage.deleteSentence(playerId);
-                } catch (UnsupportedOperationException ex) {
-                    changed = true;
-                }
-            }
-        }
-
-
-        if (changed) {
-            try {
-                storage.saveSentences(active);
-            } catch (Throwable ignored) {}
-        }
-
-        for (Map.Entry<UUID, JailModels.Sentence> e : active.entrySet()) {
-            Player p = Bukkit.getPlayer(e.getKey());
-            if (p == null || !p.isOnline()) continue;
-
-            JailModels.Jail j = jails.get(e.getValue().jailName);
-            if (j == null || !j.isValid()) continue;
-
-            if (!p.getWorld().getName().equalsIgnoreCase(j.world)
-                    || !j.region.contains(p.getLocation())) {
-
-                Location spawn = j.cells.get(e.getValue().cellId);
-                if (spawn == null && !j.cells.isEmpty()) {
-                    spawn = j.cells.values().iterator().next();
-                }
-
-                if (spawn != null) {
-                    final Location finalSpawn = spawn;
+                if (p != null) {
                     OreScheduler.runForEntity(plugin, p, () -> {
-                        if (OreScheduler.isFolia()) {
-                            p.teleportAsync(finalSpawn);
-                        } else {
-                            p.teleport(finalSpawn);
-                        }
-                        p.sendMessage("§cYou cannot escape from jail!");
+                        if (p.isOnline()) p.sendMessage("§aYour jail time is over.");
                     });
                 }
+                OreScheduler.runAsync(plugin, () -> {
+                    try { storage.deleteSentence(playerId); }
+                    catch (UnsupportedOperationException ex) {
+                        try { storage.saveSentences(new HashMap<>(active)); } catch (Throwable ignored) {}
+                    } catch (Throwable t) {
+                        plugin.getLogger().warning("[Jails] Failed removing expired sentence: " + t.getMessage());
+                    }
+                });
+                continue;
             }
+
+            Player p = Bukkit.getPlayer(playerId);
+            if (p == null) continue;
+            JailModels.Jail jail = jails.get(sentence.jailName);
+            if (jail == null || !jail.isValid()) continue;
+
+            Location cell = jail.cells.get(sentence.cellId);
+            if (cell == null && !jail.cells.isEmpty()) cell = jail.cells.values().iterator().next();
+            final Location finalCell = cell == null ? null : cell.clone();
+            if (finalCell == null) continue;
+
+            OreScheduler.runForEntity(plugin, p, () -> {
+                if (!p.isOnline() || active.get(playerId) != sentence) return;
+                boolean outside = !p.getWorld().getName().equalsIgnoreCase(jail.world)
+                        || !jail.region.contains(p.getLocation());
+                if (!outside) return;
+
+                if (OreScheduler.isFolia()) p.teleportAsync(finalCell);
+                else p.teleport(finalCell);
+                p.sendMessage("§cYou cannot escape from jail!");
+            });
         }
     }
 
-    /**
-     * Teleport jailed player back to their cell.
-     * Used by PlayerJoinEvent listener.
-     */
     public void teleportToCell(UUID player) {
         JailModels.Sentence s = active.get(player);
         if (s == null) return;
-
         JailModels.Jail jail = jails.get(s.jailName);
         if (jail == null || !jail.isValid()) return;
 
         Location spawn = jail.cells.get(s.cellId);
-        if (spawn == null && !jail.cells.isEmpty()) {
-            spawn = jail.cells.values().iterator().next();
-        }
+        if (spawn == null && !jail.cells.isEmpty()) spawn = jail.cells.values().iterator().next();
+        if (spawn == null) return;
 
-        if (spawn != null) {
-            Player p = Bukkit.getPlayer(player);
-            if (p != null && p.isOnline()) {
-                final Location finalSpawn = spawn;
-                // Delay to ensure world is loaded
-                OreScheduler.runLaterForEntity(plugin, p, () -> {
-                    if (OreScheduler.isFolia()) {
-                        p.teleportAsync(finalSpawn);
-                    } else {
-                        p.teleport(finalSpawn);
-                    }
+        Player p = Bukkit.getPlayer(player);
+        if (p == null) return;
+        Location finalSpawn = spawn.clone();
+        OreScheduler.runLaterForEntity(plugin, p, () -> {
+            if (!p.isOnline()) return;
+            if (OreScheduler.isFolia()) p.teleportAsync(finalSpawn);
+            else p.teleport(finalSpawn);
 
-                    long remaining = s.remainingMs();
-                    if (remaining > 0) {
-                        p.sendMessage("§cYou are still jailed for " + TimeText.format(remaining));
-                    } else if (s.endEpochMs == 0) {
-                        p.sendMessage("§cYou are permanently jailed.");
-                    }
-                }, 5L);
-            }
-        }
+            long remaining = s.remainingMs();
+            if (remaining > 0) p.sendMessage("§cYou are still jailed for " + TimeText.format(remaining));
+            else if (s.endEpochMs == 0) p.sendMessage("§cYou are permanently jailed.");
+        }, 5L);
     }
 
     public boolean isCommandBlockedFor(Player p, String baseCmd) {
-        JailModels.Sentence s = active.get(p.getUniqueId());
-        return s != null && blockedCommands.contains(baseCmd.toLowerCase(Locale.ROOT));
+        return active.containsKey(p.getUniqueId()) && blockedCommands.contains(baseCmd.toLowerCase(Locale.ROOT));
     }
 
-    public Set<String> getBlockedCommands() {
-        return Collections.unmodifiableSet(blockedCommands);
-    }
+    public Set<String> getBlockedCommands() { return blockedCommands; }
 }

--- a/src/main/java/fr/elias/oreoEssentials/modules/mobs/HealthBarListener.java
+++ b/src/main/java/fr/elias/oreoEssentials/modules/mobs/HealthBarListener.java
@@ -15,6 +15,7 @@ import org.bukkit.attribute.Attribute;
 import org.bukkit.entity.*;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
+import org.bukkit.event.HandlerList;
 import org.bukkit.event.Listener;
 import org.bukkit.event.entity.*;
 import org.bukkit.event.world.ChunkUnloadEvent;
@@ -29,6 +30,8 @@ public final class HealthBarListener implements Listener {
     private static final String HOLO_TAG = "oe_mobhb";
     private static final double DEFAULT_Y_OFFSET = 0.5;
     private static final Attribute MAX_HEALTH_ATTR = resolveMaxHealthAttribute();
+    private static final Object INSTANCE_LOCK = new Object();
+    private static HealthBarListener activeInstance;
 
     private static final MiniMessage MM = MiniMessage.miniMessage();
     private static final LegacyComponentSerializer LEGACY =
@@ -113,6 +116,17 @@ public final class HealthBarListener implements Listener {
         this.requireLOS      = hb == null || hb.getBoolean("require-line-of-sight", true);
         this.spawnPerTickCap = (hb != null) ? Math.max(1, hb.getInt("spawn-per-tick-cap", 40)) : 40;
 
+        // /oereload creates a fresh HealthBarListener. Retire the previous instance
+        // before activating this one so old listeners/sweepers cannot accumulate.
+        synchronized (INSTANCE_LOCK) {
+            HealthBarListener previous = activeInstance;
+            activeInstance = this;
+            if (previous != null && previous != this) {
+                previous.shutdownInternal(false);
+                HandlerList.unregisterAll(previous);
+            }
+        }
+
         if (enabled) {
             sweeper = OreScheduler.runTimer(plugin, this::sweepTick, updateInterval, updateInterval);
         }
@@ -121,11 +135,20 @@ public final class HealthBarListener implements Listener {
     public boolean isEnabled() { return enabled; }
 
     public void shutdown() {
+        shutdownInternal(true);
+    }
+
+    private void shutdownInternal(boolean clearActive) {
         if (sweeper != null) { sweeper.cancel(); sweeper = null; }
         removeAll(topLine);
         removeAll(bottomLine);
         topLine.clear();
         bottomLine.clear();
+        if (clearActive) {
+            synchronized (INSTANCE_LOCK) {
+                if (activeInstance == this) activeInstance = null;
+            }
+        }
     }
 
     @EventHandler(ignoreCancelled = true, priority = EventPriority.MONITOR)
@@ -198,13 +221,6 @@ public final class HealthBarListener implements Listener {
     }
 
     private void sweepTick() {
-        // On Folia the GlobalRegionScheduler has no region ownership:
-        // getNearbyEntities(), getEntities(), getEntity(uuid), and entity
-        // teleport all require the owning region thread.  Health-bar
-        // creation/updates still happen through onSpawn/onDamage/onRegain
-        // events, so no bars are silently lost – only the proactive sweep
-        // (which shows bars for mobs already in range before a damage event)
-        // is skipped.
         if (OreScheduler.isFolia()) return;
 
         int created = 0;
@@ -532,7 +548,6 @@ public final class HealthBarListener implements Listener {
     private void removeStand(ArmorStand as) {
         if (as == null || as.isDead()) return;
         if (OreScheduler.isFolia()) {
-            // ArmorStand removal must run on its owning region thread on Folia.
             as.getScheduler().run(plugin, ctx -> { try { as.remove(); } catch (Throwable ignored) {} }, null);
         } else {
             try { as.remove(); } catch (Throwable ignored) {}

--- a/src/main/java/fr/elias/oreoEssentials/modules/playtime/PlaytimeTracker.java
+++ b/src/main/java/fr/elias/oreoEssentials/modules/playtime/PlaytimeTracker.java
@@ -6,7 +6,10 @@ import fr.elias.oreoEssentials.util.OreTask;
 import org.bukkit.Bukkit;
 import org.bukkit.configuration.file.YamlConfiguration;
 import org.bukkit.entity.Player;
-import org.bukkit.event.*;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.HandlerList;
+import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerJoinEvent;
 import org.bukkit.event.player.PlayerQuitEvent;
 
@@ -14,30 +17,24 @@ import java.io.File;
 import java.io.IOException;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
-
+import java.util.concurrent.atomic.AtomicBoolean;
 
 public final class PlaytimeTracker implements Listener {
 
     private final OreoEssentials plugin;
-
     private final Map<UUID, Long> totals = new ConcurrentHashMap<>();
-
     private final Map<UUID, Long> onlineSince = new ConcurrentHashMap<>();
-
     private final Set<UUID> baselined = Collections.newSetFromMap(new ConcurrentHashMap<>());
-
     private final File file;
-    private YamlConfiguration yaml;
-
-    private OreTask autosaveTask = null;
+    private final AtomicBoolean saveQueued = new AtomicBoolean(false);
+    private OreTask autosaveTask;
 
     public PlaytimeTracker(OreoEssentials plugin) {
         this.plugin = plugin;
         this.file = new File(plugin.getDataFolder(), "playtime_data.yml");
         load();
         Bukkit.getPluginManager().registerEvents(this, plugin);
-
-        autosaveTask = OreScheduler.runTimer(plugin, this::saveQuiet, 20L * 60, 20L * 60);
+        autosaveTask = OreScheduler.runTimer(plugin, this::saveQuietAsync, 20L * 60, 20L * 60);
     }
 
     public void shutdown() {
@@ -46,22 +43,21 @@ public final class PlaytimeTracker implements Listener {
             autosaveTask = null;
         }
         flushOnlineDeltas();
-        saveQuiet();
+        // Plugin shutdown should leave data on disk before returning, so this final write is synchronous.
+        saveSnapshot(snapshotTotals(), snapshotBaselined());
         HandlerList.unregisterAll(this);
     }
-
 
     private void load() {
         try {
             if (!file.exists()) {
-                file.getParentFile().mkdirs();
-                yaml = new YamlConfiguration();
-                yaml.save(file);
+                File parent = file.getParentFile();
+                if (parent != null) parent.mkdirs();
+                new YamlConfiguration().save(file);
             }
-            yaml = YamlConfiguration.loadConfiguration(file);
-
-            if (yaml.isConfigurationSection("totals")) {
-                for (String k : yaml.getConfigurationSection("totals").getKeys(false)) {
+            YamlConfiguration yaml = YamlConfiguration.loadConfiguration(file);
+            if (yaml.isConfigurationSection("totals") && yaml.getConfigurationSection("totals") != null) {
+                for (String k : Objects.requireNonNull(yaml.getConfigurationSection("totals")).getKeys(false)) {
                     try {
                         UUID u = UUID.fromString(k);
                         totals.put(u, yaml.getLong("totals." + k, 0L));
@@ -72,22 +68,42 @@ public final class PlaytimeTracker implements Listener {
             for (String s : yaml.getStringList("baselined")) {
                 try { baselined.add(UUID.fromString(s)); } catch (IllegalArgumentException ignored) {}
             }
-
         } catch (Exception e) {
             plugin.getLogger().warning("[PlaytimeTracker] Failed to load: " + e.getMessage());
-            yaml = new YamlConfiguration();
         }
     }
 
-    private void saveQuiet() {
+    private void saveQuietAsync() {
+        flushOnlineDeltas();
+        if (!saveQueued.compareAndSet(false, true)) return;
+
+        Map<UUID, Long> totalsSnapshot = snapshotTotals();
+        List<UUID> baselinedSnapshot = snapshotBaselined();
+        OreScheduler.runAsync(plugin, () -> {
+            try {
+                saveSnapshot(totalsSnapshot, baselinedSnapshot);
+            } finally {
+                saveQueued.set(false);
+            }
+        });
+    }
+
+    private Map<UUID, Long> snapshotTotals() {
+        return new HashMap<>(totals);
+    }
+
+    private List<UUID> snapshotBaselined() {
+        return new ArrayList<>(baselined);
+    }
+
+    private void saveSnapshot(Map<UUID, Long> totalsSnapshot, Collection<UUID> baselinedSnapshot) {
         try {
             YamlConfiguration out = new YamlConfiguration();
-            flushOnlineDeltas();
-            for (Map.Entry<UUID, Long> e : totals.entrySet()) {
+            for (Map.Entry<UUID, Long> e : totalsSnapshot.entrySet()) {
                 out.set("totals." + e.getKey(), e.getValue());
             }
-            List<String> bl = new ArrayList<>();
-            for (UUID u : baselined) bl.add(u.toString());
+            List<String> bl = new ArrayList<>(baselinedSnapshot.size());
+            for (UUID u : baselinedSnapshot) bl.add(u.toString());
             out.set("baselined", bl);
             out.save(file);
         } catch (IOException e) {
@@ -101,39 +117,31 @@ public final class PlaytimeTracker implements Listener {
             UUID u = e.getKey();
             long start = e.getValue();
             long addSec = Math.max(0, (now - start) / 1000L);
-            totals.merge(u, addSec, Long::sum);
-            onlineSince.put(u, now); // reset baseline to now
+            if (addSec > 0) totals.merge(u, addSec, Long::sum);
+            onlineSince.replace(u, start, now);
         }
     }
-
 
     public long getSeconds(UUID uuid) {
         long base = totals.getOrDefault(uuid, 0L);
         Long start = onlineSince.get(uuid);
-        if (start != null) {
-            base += Math.max(0, (System.currentTimeMillis() - start) / 1000L);
-        }
+        if (start != null) base += Math.max(0, (System.currentTimeMillis() - start) / 1000L);
         return Math.max(0, base);
     }
 
     public void baselineFromBukkitIfNeeded(Player p) {
-        if (baselined.contains(p.getUniqueId())) return;
-        baselined.add(p.getUniqueId());
-        // set internal total to current vanilla seconds (acts as a baseline, so no retro payouts later)
+        if (!baselined.add(p.getUniqueId())) return;
         int ticks = p.getStatistic(org.bukkit.Statistic.PLAY_ONE_MINUTE);
-        long sec = Math.max(0, ticks / 20L);
-        totals.put(p.getUniqueId(), sec);
+        totals.put(p.getUniqueId(), Math.max(0, ticks / 20L));
     }
-
 
     @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public void onJoin(PlayerJoinEvent e) {
         Player p = e.getPlayer();
         onlineSince.put(p.getUniqueId(), System.currentTimeMillis());
-
-        boolean baseline = plugin.getConfig().getBoolean("playtime.internal.baseline-from-bukkit-on-first-seen",
-                false);
-        if (baseline) baselineFromBukkitIfNeeded(p);
+        if (plugin.getConfig().getBoolean("playtime.internal.baseline-from-bukkit-on-first-seen", false)) {
+            baselineFromBukkitIfNeeded(p);
+        }
     }
 
     @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
@@ -142,8 +150,8 @@ public final class PlaytimeTracker implements Listener {
         Long start = onlineSince.remove(p.getUniqueId());
         if (start != null) {
             long addSec = Math.max(0, (System.currentTimeMillis() - start) / 1000L);
-            totals.merge(p.getUniqueId(), addSec, Long::sum);
+            if (addSec > 0) totals.merge(p.getUniqueId(), addSec, Long::sum);
         }
-        saveQuiet();
+        saveQuietAsync();
     }
 }

--- a/src/main/java/fr/elias/oreoEssentials/modules/portals/rabbit/PortalsCrossServerBroker.java
+++ b/src/main/java/fr/elias/oreoEssentials/modules/portals/rabbit/PortalsCrossServerBroker.java
@@ -18,26 +18,13 @@ import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-/**
- * Handles incoming PortalTeleportPacket messages and pending cross-server teleports.
- *
- * Flow:
- *  1. Server A detects player in cross-server portal
- *  2. Server A sends PortalTeleportPacket(playerId, destWorld, x/y/z/yaw/pitch) → Server B
- *  3. Server A sends BungeeCord "Connect" plugin message to transfer the player to Server B
- *  4. This broker on Server B receives the packet and stores a pending teleport
- *  5. On PlayerJoinEvent, the pending teleport is executed
- */
 public final class PortalsCrossServerBroker implements Listener {
 
-    /** playerId → pending teleport info */
     private final ConcurrentHashMap<UUID, PendingTeleport> pending = new ConcurrentHashMap<>();
-    /** requestId dedup — prevents double-teleports on redelivery */
     private final ConcurrentHashMap<UUID, String> lastRequestId = new ConcurrentHashMap<>();
-
     private final OreoEssentials plugin;
 
-    private static final record PendingTeleport(
+    private record PendingTeleport(
             String worldName, double x, double y, double z,
             float yaw, float pitch, boolean keepYawPitch, String requestId) {}
 
@@ -48,20 +35,27 @@ public final class PortalsCrossServerBroker implements Listener {
         pm.subscribe(PortalTeleportPacket.class, (channel, pkt) -> {
             if (pkt.getPlayerId() == null) return;
 
-            // Dedup
             String last = lastRequestId.get(pkt.getPlayerId());
             if (pkt.getRequestId() != null && pkt.getRequestId().equals(last)) return;
             lastRequestId.put(pkt.getPlayerId(), pkt.getRequestId());
 
+            PendingTeleport pt = new PendingTeleport(
+                    pkt.getWorldName(), pkt.getX(), pkt.getY(), pkt.getZ(),
+                    pkt.getYaw(), pkt.getPitch(), pkt.isKeepYawPitch(), pkt.getRequestId());
+
             Player online = Bukkit.getPlayer(pkt.getPlayerId());
-            if (online != null && online.isOnline()) {
-                applyTeleport(online, pkt.getWorldName(), pkt.getX(), pkt.getY(), pkt.getZ(),
-                        pkt.getYaw(), pkt.getPitch(), pkt.isKeepYawPitch());
-            } else {
-                pending.put(pkt.getPlayerId(), new PendingTeleport(
-                        pkt.getWorldName(), pkt.getX(), pkt.getY(), pkt.getZ(),
-                        pkt.getYaw(), pkt.getPitch(), pkt.isKeepYawPitch(), pkt.getRequestId()));
+            if (online == null) {
+                pending.put(pkt.getPlayerId(), pt);
+                return;
             }
+
+            OreScheduler.runForEntity(plugin, online, () -> {
+                if (!online.isOnline()) {
+                    pending.put(pkt.getPlayerId(), pt);
+                    return;
+                }
+                applyTeleportOnEntityThread(online, pt);
+            });
         });
     }
 
@@ -71,50 +65,33 @@ public final class PortalsCrossServerBroker implements Listener {
         PendingTeleport pt = pending.remove(p.getUniqueId());
         if (pt == null) return;
 
-        // Try at 1, 5, 20 ticks to catch slow world loads.
-        // AtomicBoolean ensures only the FIRST successful attempt fires — prevents triple-teleport.
         AtomicBoolean done = new AtomicBoolean(false);
-        long[] delays = {1L, 5L, 20L};
-        for (long delay : delays) {
-            OreScheduler.runLater(plugin, () -> {
+        for (long delay : new long[]{1L, 5L, 20L}) {
+            OreScheduler.runLaterForEntity(plugin, p, () -> {
                 if (!p.isOnline() || done.get()) return;
-                // Only proceed once the destination world is actually loaded
-                if (Bukkit.getWorld(pt.worldName()) == null) return;
-                if (done.compareAndSet(false, true)) {
-                    applyTeleport(p, pt.worldName(), pt.x(), pt.y(), pt.z(),
-                            pt.yaw(), pt.pitch(), pt.keepYawPitch());
-                }
+                World world = Bukkit.getWorld(pt.worldName());
+                if (world == null) return;
+                if (done.compareAndSet(false, true)) applyTeleportOnEntityThread(p, pt);
             }, delay);
         }
     }
 
-    private void applyTeleport(Player p, String worldName, double x, double y, double z,
-                                float yaw, float pitch, boolean keepYawPitch) {
-        World world = Bukkit.getWorld(worldName);
+    private void applyTeleportOnEntityThread(Player p, PendingTeleport pt) {
+        World world = Bukkit.getWorld(pt.worldName());
         if (world == null) {
-            plugin.getLogger().warning("[Portals] Cross-server teleport: world '" + worldName
+            plugin.getLogger().warning("[Portals] Cross-server teleport: world '" + pt.worldName()
                     + "' not found on this server.");
             return;
         }
 
-        float finalYaw   = keepYawPitch ? p.getLocation().getYaw()   : yaw;
-        float finalPitch = keepYawPitch ? p.getLocation().getPitch() : pitch;
-        Location dest = new Location(world, x, y, z, finalYaw, finalPitch);
+        float finalYaw = pt.keepYawPitch() ? p.getLocation().getYaw() : pt.yaw();
+        float finalPitch = pt.keepYawPitch() ? p.getLocation().getPitch() : pt.pitch();
+        Location dest = new Location(world, pt.x(), pt.y(), pt.z(), finalYaw, finalPitch);
 
-        OreScheduler.runForEntity(plugin, p, () -> {
-            if (!p.isOnline()) return;
-            if (OreScheduler.isFolia()) {
-                p.teleportAsync(dest);
-            } else {
-                p.teleport(dest);
-            }
-        });
+        if (OreScheduler.isFolia()) p.teleportAsync(dest);
+        else p.teleport(dest);
     }
 
-    /**
-     * Sends a BungeeCord "Connect" plugin message to transfer a player to another server.
-     * Requires "BungeeCord" channel registered in plugin.yml (bungeecord: true in spigot.yml).
-     */
     public static void connectToServer(OreoEssentials plugin, Player player, String serverName) {
         try {
             ByteArrayOutputStream b = new ByteArrayOutputStream();
@@ -127,23 +104,16 @@ public final class PortalsCrossServerBroker implements Listener {
         }
     }
 
-    /**
-     * Sends a cross-server portal teleport request:
-     *  - Queues the destination teleport on the target server via RabbitMQ
-     *  - Then transfers the player via BungeeCord plugin message
-     */
     public void sendCrossServerPortal(PacketManager pm, Player player,
                                       String destServer, String destWorld,
                                       double x, double y, double z,
                                       float yaw, float pitch, boolean keepYawPitch) {
         PortalTeleportPacket pkt = new PortalTeleportPacket(
                 player.getUniqueId(), destWorld, x, y, z, yaw, pitch, keepYawPitch);
-
-        // Send the destination info to the target server first, then switch the player
         pm.sendPacket(PacketChannels.individual(destServer), pkt);
 
-        // Small delay to give RabbitMQ time to deliver before the player arrives
-        OreScheduler.runLater(plugin, () ->
-                connectToServer(plugin, player, destServer), 3L);
+        OreScheduler.runLaterForEntity(plugin, player, () -> {
+            if (player.isOnline()) connectToServer(plugin, player, destServer);
+        }, 3L);
     }
 }

--- a/src/main/java/fr/elias/oreoEssentials/modules/tempfly/TempFlyService.java
+++ b/src/main/java/fr/elias/oreoEssentials/modules/tempfly/TempFlyService.java
@@ -22,14 +22,12 @@ public class TempFlyService implements Listener {
     private final OreoEssentials plugin;
     private final TempFlyConfig config;
     private final Map<UUID, TempFlySession> activeSessions = new ConcurrentHashMap<>();
-    private OreTask taskId = null;
+    private OreTask taskId;
 
     public TempFlyService(OreoEssentials plugin, TempFlyConfig config) {
         this.plugin = plugin;
         this.config = config;
-
         Bukkit.getPluginManager().registerEvents(this, plugin);
-
         this.taskId = OreScheduler.runTimer(plugin, this::tick, 20L, 20L);
     }
 
@@ -38,12 +36,14 @@ public class TempFlyService implements Listener {
             taskId.cancel();
             taskId = null;
         }
-
         for (TempFlySession session : activeSessions.values()) {
             Player p = Bukkit.getPlayer(session.playerId);
-            if (p != null && p.isOnline()) {
-                p.setAllowFlight(false);
-                p.setFlying(false);
+            if (p != null) {
+                OreScheduler.runForEntity(plugin, p, () -> {
+                    if (!p.isOnline()) return;
+                    p.setAllowFlight(false);
+                    p.setFlying(false);
+                });
             }
         }
         activeSessions.clear();
@@ -51,34 +51,27 @@ public class TempFlyService implements Listener {
 
     public void enableFly(Player player) {
         if (player == null) return;
-
         int duration = getDurationForPlayer(player);
         if (duration <= 0) {
             player.sendMessage("§cYou don't have permission to use temporary fly.");
             return;
         }
-
         if (activeSessions.containsKey(player.getUniqueId())) {
             player.sendMessage("§cYou already have temporary fly active.");
             return;
         }
-
-        TempFlySession session = new TempFlySession(player.getUniqueId(), duration);
-        activeSessions.put(player.getUniqueId(), session);
-
+        activeSessions.put(player.getUniqueId(), new TempFlySession(player.getUniqueId(), duration));
         player.setAllowFlight(true);
         player.sendMessage("§aTemporary fly enabled for §e" + formatTime(duration) + "§a.");
     }
 
     public void disableFly(Player player) {
         if (player == null) return;
-
         TempFlySession session = activeSessions.remove(player.getUniqueId());
         if (session == null) {
             player.sendMessage("§cYou don't have temporary fly active.");
             return;
         }
-
         player.setAllowFlight(false);
         player.setFlying(false);
         player.sendMessage("§cTemporary fly disabled.");
@@ -94,82 +87,70 @@ public class TempFlyService implements Listener {
         for (Map.Entry<UUID, TempFlySession> entry : activeSessions.entrySet()) {
             UUID playerId = entry.getKey();
             TempFlySession session = entry.getValue();
-
             Player player = Bukkit.getPlayer(playerId);
-            if (player == null || !player.isOnline()) {
-                activeSessions.remove(playerId);
+            if (player == null) {
+                activeSessions.remove(playerId, session);
                 continue;
             }
 
-            session.remainingSeconds--;
+            OreScheduler.runForEntity(plugin, player, () -> {
+                if (!player.isOnline() || activeSessions.get(playerId) != session) return;
 
-            if (session.remainingSeconds <= 0) {
-                activeSessions.remove(playerId);
-                player.setAllowFlight(false);
-                player.setFlying(false);
-                player.sendMessage("§cYour temporary fly time has expired.");
-                continue;
-            }
-
-            int[] warnings = {60, 30, 10, 5};
-            for (int warn : warnings) {
-                if (session.remainingSeconds == warn) {
-                    player.sendMessage("§eTemporary fly expires in §c" + formatTime(warn) + "§e.");
-                    break;
+                session.remainingSeconds--;
+                if (session.remainingSeconds <= 0) {
+                    activeSessions.remove(playerId, session);
+                    player.setAllowFlight(false);
+                    player.setFlying(false);
+                    player.sendMessage("§cYour temporary fly time has expired.");
+                    return;
                 }
-            }
+
+                int[] warnings = {60, 30, 10, 5};
+                for (int warn : warnings) {
+                    if (session.remainingSeconds == warn) {
+                        player.sendMessage("§eTemporary fly expires in §c" + formatTime(warn) + "§e.");
+                        break;
+                    }
+                }
+            });
         }
     }
 
     private int getDurationForPlayer(Player player) {
         String group = null;
         try {
-            net.luckperms.api.model.user.User lpUser = LuckPermsProvider.get()
-                    .getUserManager().getUser(player.getUniqueId());
-            if (lpUser != null) {
-                group = lpUser.getPrimaryGroup();
-            }
-        } catch (Throwable ignored) {
-        }
+            net.luckperms.api.model.user.User lpUser = LuckPermsProvider.get().getUserManager().getUser(player.getUniqueId());
+            if (lpUser != null) group = lpUser.getPrimaryGroup();
+        } catch (Throwable ignored) {}
 
         if (config.usePermissionGroups()) {
             for (String permGroup : config.getPermissionGroups().keySet()) {
-                if (player.hasPermission("oe.tempfly." + permGroup)) {
-                    return config.getPermissionGroups().get(permGroup);
-                }
+                if (player.hasPermission("oe.tempfly." + permGroup)) return config.getPermissionGroups().get(permGroup);
             }
         }
-
         if (config.useLuckPermsGroups() && group != null) {
             Integer duration = config.getLuckPermsGroups().get(group);
-            if (duration != null) {
-                return duration;
-            }
+            if (duration != null) return duration;
         }
-
         return 0;
     }
 
     private String formatTime(int seconds) {
-        if (seconds < 60) {
-            return seconds + "s";
-        } else if (seconds < 3600) {
+        if (seconds < 60) return seconds + "s";
+        if (seconds < 3600) {
             int minutes = seconds / 60;
             int secs = seconds % 60;
             return secs > 0 ? minutes + "m " + secs + "s" : minutes + "m";
-        } else {
-            int hours = seconds / 3600;
-            int minutes = (seconds % 3600) / 60;
-            return minutes > 0 ? hours + "h " + minutes + "m" : hours + "h";
         }
+        int hours = seconds / 3600;
+        int minutes = (seconds % 3600) / 60;
+        return minutes > 0 ? hours + "h " + minutes + "m" : hours + "h";
     }
 
     @EventHandler
     public void onJoin(PlayerJoinEvent event) {
         Player player = event.getPlayer();
-        if (player.hasPermission("oe.tempfly.infinite")) {
-            player.setAllowFlight(true);
-        }
+        if (player.hasPermission("oe.tempfly.infinite")) player.setAllowFlight(true);
     }
 
     @EventHandler
@@ -187,7 +168,6 @@ public class TempFlyService implements Listener {
     private static class TempFlySession {
         final UUID playerId;
         int remainingSeconds;
-
         TempFlySession(UUID playerId, int duration) {
             this.playerId = playerId;
             this.remainingSeconds = duration;

--- a/src/main/java/fr/elias/oreoEssentials/modules/tp/command/TphereCommand.java
+++ b/src/main/java/fr/elias/oreoEssentials/modules/tp/command/TphereCommand.java
@@ -5,6 +5,7 @@ import fr.elias.oreoEssentials.commands.OreoCommand;
 import fr.elias.oreoEssentials.util.Lang;
 import fr.elias.oreoEssentials.util.OreScheduler;
 import org.bukkit.Bukkit;
+import org.bukkit.Location;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 
@@ -19,9 +20,7 @@ public class TphereCommand implements OreoCommand, org.bukkit.command.TabComplet
 
     private final OreoEssentials plugin;
 
-    public TphereCommand(OreoEssentials plugin) {
-        this.plugin = plugin;
-    }
+    public TphereCommand(OreoEssentials plugin) { this.plugin = plugin; }
 
     @Override public String name() { return "tphere"; }
     @Override public List<String> aliases() { return List.of(); }
@@ -32,83 +31,62 @@ public class TphereCommand implements OreoCommand, org.bukkit.command.TabComplet
     @Override
     public boolean execute(CommandSender sender, String label, String[] args) {
         Player self = (Player) sender;
-
         if (args.length < 1) {
-            Lang.send(self, "admin.tphere.usage",
-                    "<yellow>Usage: /%label% <player></yellow>",
-                    Map.of("label", label));
+            Lang.send(self, "admin.tphere.usage", "<yellow>Usage: /%label% <player></yellow>", Map.of("label", label));
             return true;
         }
 
         Player target = Bukkit.getPlayerExact(args[0]);
         if (target == null) {
-            Lang.send(self, "admin.tphere.not-found",
-                    "<red>Player not found: <yellow>%target%</yellow>.</red>",
-                    Map.of("target", args[0]));
+            Lang.send(self, "admin.tphere.not-found", "<red>Player not found: <yellow>%target%</yellow>.</red>", Map.of("target", args[0]));
             return true;
         }
 
-        final Player finalTarget = target;
-        final Player finalSelf = self;
-        OreScheduler.runForEntity(plugin, target, () -> {
-            if (OreScheduler.isFolia()) {
-                finalTarget.teleportAsync(finalSelf.getLocation());
-            } else {
-                finalTarget.teleport(finalSelf.getLocation());
-            }
+        OreScheduler.runForEntity(plugin, self, () -> {
+            if (!self.isOnline()) return;
+            final Location destination = self.getLocation().clone();
+            final String selfName = self.getName();
+            final String targetName = target.getName();
 
-            Lang.send(finalSelf, "admin.tphere.brought",
-                    "<green>Brought <aqua>%target%</aqua> to you.</green>",
-                    Map.of("target", finalTarget.getName()));
-
-            if (!finalTarget.equals(finalSelf)) {
-                Lang.send(finalTarget, "admin.tphere.notice",
-                        "<yellow>You were teleported to <aqua>%player%</aqua>.</yellow>",
-                        Map.of("player", finalSelf.getName()));
-            }
+            OreScheduler.runForEntity(plugin, target, () -> {
+                if (!target.isOnline()) return;
+                if (OreScheduler.isFolia()) {
+                    target.teleportAsync(destination).whenComplete((ok, err) -> {
+                        OreScheduler.runForEntity(plugin, self, () -> {
+                            if (err == null && Boolean.TRUE.equals(ok)) {
+                                Lang.send(self, "admin.tphere.brought", "<green>Brought <aqua>%target%</aqua> to you.</green>", Map.of("target", targetName));
+                            } else {
+                                Lang.send(self, "admin.tphere.failed", "<red>Teleport failed.</red>");
+                            }
+                        });
+                        if (!target.equals(self) && err == null && Boolean.TRUE.equals(ok)) {
+                            OreScheduler.runForEntity(plugin, target, () -> Lang.send(target, "admin.tphere.notice", "<yellow>You were teleported to <aqua>%player%</aqua>.</yellow>", Map.of("player", selfName)));
+                        }
+                    });
+                } else {
+                    boolean ok = target.teleport(destination);
+                    if (ok) {
+                        Lang.send(self, "admin.tphere.brought", "<green>Brought <aqua>%target%</aqua> to you.</green>", Map.of("target", targetName));
+                        if (!target.equals(self)) Lang.send(target, "admin.tphere.notice", "<yellow>You were teleported to <aqua>%player%</aqua>.</yellow>", Map.of("player", selfName));
+                    } else {
+                        Lang.send(self, "admin.tphere.failed", "<red>Teleport failed.</red>");
+                    }
+                }
+            });
         });
-
         return true;
     }
 
     @Override
-    public List<String> onTabComplete(CommandSender sender,
-                                      org.bukkit.command.Command cmd,
-                                      String alias,
-                                      String[] args) {
-        if (args.length != 1) {
-            return List.of();
-        }
-
-        final String partial = args[0];
-        final String want = partial.toLowerCase(Locale.ROOT);
-
-        // Sorted, case-insensitive
+    public List<String> onTabComplete(CommandSender sender, org.bukkit.command.Command cmd, String alias, String[] args) {
+        if (args.length != 1) return List.of();
+        String want = args[0].toLowerCase(Locale.ROOT);
         Set<String> out = new TreeSet<>(String.CASE_INSENSITIVE_ORDER);
-
-        // 1) Local online players
         for (Player p : Bukkit.getOnlinePlayers()) {
             String n = p.getName();
-            if (n != null && n.toLowerCase(Locale.ROOT).startsWith(want)) {
-                out.add(n);
-            }
+            if (n != null && n.toLowerCase(Locale.ROOT).startsWith(want)) out.add(n);
         }
-
-        // 2) Network-wide suggestions (if directory available)
-        var dir = plugin.getPlayerDirectory();
-        if (dir != null) {
-            try {
-                var names = dir.suggestOnlineNames(want, 50);
-                if (names != null) {
-                    for (String n : names) {
-                        if (n != null && n.toLowerCase(Locale.ROOT).startsWith(want)) {
-                            out.add(n);
-                        }
-                    }
-                }
-            } catch (Throwable ignored) {}
-        }
-
+        // Deliberately do not query PlayerDirectory/MongoDB from tab completion.
         return out.stream().limit(50).collect(Collectors.toList());
     }
 }

--- a/src/main/java/fr/elias/oreoEssentials/modules/tp/rabbit/brokers/TpaCrossServerBroker.java
+++ b/src/main/java/fr/elias/oreoEssentials/modules/tp/rabbit/brokers/TpaCrossServerBroker.java
@@ -1,12 +1,12 @@
 package fr.elias.oreoEssentials.modules.tp.rabbit.brokers;
 
 import fr.elias.oreoEssentials.OreoEssentials;
-import fr.elias.oreoEssentials.rabbitmq.PacketChannels;
-import fr.elias.oreoEssentials.rabbitmq.channel.PacketChannel;
-import fr.elias.oreoEssentials.rabbitmq.packet.PacketManager;
 import fr.elias.oreoEssentials.modules.tp.rabbit.packets.TpaRequestPacket;
 import fr.elias.oreoEssentials.modules.tp.rabbit.packets.TpaSummonPacket;
 import fr.elias.oreoEssentials.modules.tp.service.TeleportService;
+import fr.elias.oreoEssentials.rabbitmq.PacketChannels;
+import fr.elias.oreoEssentials.rabbitmq.channel.PacketChannel;
+import fr.elias.oreoEssentials.rabbitmq.packet.PacketManager;
 import fr.elias.oreoEssentials.util.Lang;
 import fr.elias.oreoEssentials.util.OreScheduler;
 import fr.elias.oreoEssentials.util.OreTask;
@@ -20,7 +20,6 @@ import org.bukkit.event.player.PlayerJoinEvent;
 import org.bukkit.event.player.PlayerQuitEvent;
 
 import java.lang.reflect.Method;
-import java.util.Iterator;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
@@ -28,6 +27,7 @@ import java.util.concurrent.ConcurrentHashMap;
 public final class TpaCrossServerBroker implements Listener {
 
     private final OreoEssentials plugin;
+    @SuppressWarnings("unused")
     private final TeleportService teleportService;
     private final PacketManager pm;
     private final ProxyMessenger proxy;
@@ -35,11 +35,10 @@ public final class TpaCrossServerBroker implements Listener {
 
     private final Map<UUID, Pending> pendingForTarget = new ConcurrentHashMap<>();
     private final Map<UUID, UUID> pendingArrival = new ConcurrentHashMap<>();
-
     private final long expireMs;
     private final boolean offlineUuidCompat;
 
-    private static class Pending {
+    private static final class Pending {
         UUID requesterUuid;
         String requesterName;
         String fromServer;
@@ -54,28 +53,16 @@ public final class TpaCrossServerBroker implements Listener {
         this.proxy = proxy;
         this.localServer = localServer;
 
-        long cfgSec = 60L;
-        try {
-            cfgSec = plugin.getConfig().getLong("features.tpa.expire-seconds",
-                    plugin.getConfig().getLong("tpa.expire-seconds", 60L));
-            if (cfgSec <= 0) cfgSec = 60L;
-        } catch (Throwable ignored) {}
+        long cfgSec = plugin.getConfig().getLong("features.tpa.expire-seconds",
+                plugin.getConfig().getLong("tpa.expire-seconds", 60L));
+        if (cfgSec <= 0) cfgSec = 60L;
         this.expireMs = cfgSec * 1000L;
-
-        boolean compat = true;
-        try {
-            compat = plugin.getConfig().getBoolean("features.tpa.offline-uuid-compat", true);
-        } catch (Throwable ignored) {}
-        this.offlineUuidCompat = compat;
+        this.offlineUuidCompat = plugin.getConfig().getBoolean("features.tpa.offline-uuid-compat", true);
 
         if (pm != null && pm.isInitialized()) {
             pm.subscribe(TpaRequestPacket.class, this::onTpaRequest);
             pm.subscribe(TpaSummonPacket.class, this::onTpaSummon);
-            dbg("Subscribed TpaRequestPacket + TpaSummonPacket (expire=" + cfgSec + "s, offlineCompat=" + offlineUuidCompat + ")");
-        } else {
-            dbg("PacketManager not initialized; cross-server TPA disabled on this node.");
         }
-
         Bukkit.getPluginManager().registerEvents(this, plugin);
         OreScheduler.runTimer(plugin, this::purgeExpired, 20L * 30, 20L * 30);
     }
@@ -91,185 +78,139 @@ public final class TpaCrossServerBroker implements Listener {
     public void sendRequestToServer(Player requester, UUID targetUuid, String targetName, String destServer) {
         if (!isMessagingReady() || requester == null) return;
         long now = System.currentTimeMillis();
-        TpaRequestPacket pkt = new TpaRequestPacket(requester.getUniqueId(), requester.getName(),
-                targetUuid, targetName != null ? targetName : "", localServer, now + expireMs);
-        pm.sendPacket(PacketChannel.individual(destServer), pkt);
-        dbg("Send TpaRequest -> server=" + destServer + " requester=" + requester.getName()
-                + " target=" + targetUuid + (targetName != null && !targetName.isBlank() ? " (" + targetName + ")" : ""));
+        pm.sendPacket(PacketChannel.individual(destServer), new TpaRequestPacket(
+                requester.getUniqueId(), requester.getName(), targetUuid,
+                targetName == null ? "" : targetName, localServer, now + expireMs));
     }
 
     public void sendRequestGlobal(Player requester, UUID targetUuid, String targetName) {
         if (!isMessagingReady() || requester == null) return;
         long now = System.currentTimeMillis();
-        TpaRequestPacket pkt = new TpaRequestPacket(requester.getUniqueId(), requester.getName(),
-                targetUuid, targetName != null ? targetName : "", localServer, now + expireMs);
-        pm.sendPacket(PacketChannels.GLOBAL, pkt);
-        dbg("Send TpaRequest (GLOBAL) requester=" + requester.getName()
-                + " target=" + targetUuid + (targetName != null && !targetName.isBlank() ? " (" + targetName + ")" : ""));
+        pm.sendPacket(PacketChannels.GLOBAL, new TpaRequestPacket(
+                requester.getUniqueId(), requester.getName(), targetUuid,
+                targetName == null ? "" : targetName, localServer, now + expireMs));
     }
 
     public boolean acceptCrossServer(Player target) {
         if (target == null) return false;
-
         Pending p = pendingForTarget.remove(target.getUniqueId());
-        if (p == null) {
-            dbg("No cross-server pending for " + target.getName());
-            return false;
-        }
+        if (p == null) return false;
 
         long now = System.currentTimeMillis();
         if (p.expiresAt > 0 && p.expiresAt < now) {
             Lang.send(target, "tpa.accept.expired", "<red>That teleport request expired.</red>");
-            dbg("Pending expired (target=" + target.getUniqueId() + ")");
             return true;
         }
-
-        if (pendingArrival.containsKey(p.requesterUuid)) {
-            Lang.send(target, "tpa.accept.busy",
-                    "<red>That requester is already being summoned to another player.</red>");
-            dbg("Rejecting accept: requester already has pending arrival " + p.requesterUuid);
+        if (pendingArrival.putIfAbsent(p.requesterUuid, target.getUniqueId()) != null) {
+            Lang.send(target, "tpa.accept.busy", "<red>That requester is already being summoned to another player.</red>");
             return true;
         }
-
-        pendingArrival.put(p.requesterUuid, target.getUniqueId());
 
         if (isMessagingReady()) {
-            pm.sendPacket(PacketChannel.individual(p.fromServer),
-                    new TpaSummonPacket(p.requesterUuid, localServer));
+            pm.sendPacket(PacketChannel.individual(p.fromServer), new TpaSummonPacket(p.requesterUuid, localServer));
         }
-
         Lang.send(target, "tpa.accept.summon",
                 "<green>Teleport request accepted.</green> <gray>Summoning</gray> <yellow>%player%</yellow><gray>…</gray>",
                 Map.of("player", p.requesterName));
-        dbg("Accept -> summon requester=" + p.requesterUuid
-                + " from=" + p.fromServer + " to=" + localServer
-                + " (target=" + target.getName() + ")");
-
-        OreScheduler.runLater(plugin,
-                () -> pendingArrival.remove(p.requesterUuid), 20L * 60);
-
+        OreScheduler.runLater(plugin, () -> pendingArrival.remove(p.requesterUuid), 20L * 60);
         return true;
     }
 
     public boolean denyCrossServer(Player target) {
         Pending p = pendingForTarget.remove(target.getUniqueId());
         if (p == null) return false;
-
         Lang.send(target, "tpa.deny.target",
                 "<yellow>Denied the teleport request from</yellow> <white>%player%</white>.",
                 Map.of("player", p.requesterName));
-        dbg("Denied pending for target=" + target.getName() + " requester=" + p.requesterUuid);
         return true;
     }
 
     public boolean hasPendingFor(Player target) {
-        return pendingForTarget.containsKey(target.getUniqueId());
+        return target != null && pendingForTarget.containsKey(target.getUniqueId());
     }
 
     private void onTpaRequest(PacketChannel channel, TpaRequestPacket pkt) {
         if (pkt == null) return;
-
         long now = System.currentTimeMillis();
-        if (pkt.getExpiresAtEpochMs() > 0 && pkt.getExpiresAtEpochMs() < now) {
-            dbg("TpaRequestPacket expired; ignoring. from=" + pkt.getFromServer());
-            return;
-        }
+        if (pkt.getExpiresAtEpochMs() > 0 && pkt.getExpiresAtEpochMs() < now) return;
 
-        Player target = resolveTarget(pkt.getTargetUuid(), pkt.getTargetName());
-        if (target == null) {
-            return;
-        }
+        Player target = resolveOnlineTarget(pkt.getTargetUuid(), pkt.getTargetName());
+        if (target == null) return;
 
         Pending p = new Pending();
         p.requesterUuid = pkt.getRequesterUuid();
         p.requesterName = pkt.getRequesterName();
         p.fromServer = pkt.getFromServer();
-        p.expiresAt = (pkt.getExpiresAtEpochMs() > 0 ? pkt.getExpiresAtEpochMs() : now + expireMs);
+        p.expiresAt = pkt.getExpiresAtEpochMs() > 0 ? pkt.getExpiresAtEpochMs() : now + expireMs;
 
-        pendingForTarget.put(target.getUniqueId(), p);
-
-        Lang.send(target, "tpa.request-target",
-                "<yellow><bold>%player%</bold></yellow> <gray>wants to teleport to you.</gray> "
-                        + "<dark_gray>(expires in</dark_gray> <white>%timeout%</white><dark_gray>s)</dark_gray> "
-                        + "<gray>Use</gray> <green>/tpaccept</green> <gray>or</gray> <red>/tpdeny</red>.",
-                Map.of("player", p.requesterName, "timeout", String.valueOf((p.expiresAt - now) / 1000L)));
-        dbg("Saved pending for target=" + target.getUniqueId() + " name=" + target.getName()
-                + " fromServer=" + p.fromServer + " expiresAt=" + p.expiresAt);
+        OreScheduler.runForEntity(plugin, target, () -> {
+            if (!target.isOnline()) return;
+            pendingForTarget.put(target.getUniqueId(), p);
+            Lang.send(target, "tpa.request-target",
+                    "<yellow><bold>%player%</bold></yellow> <gray>wants to teleport to you.</gray> "
+                            + "<dark_gray>(expires in</dark_gray> <white>%timeout%</white><dark_gray>s)</dark_gray> "
+                            + "<gray>Use</gray> <green>/tpaccept</green> <gray>or</gray> <red>/tpdeny</red>.",
+                    Map.of("player", p.requesterName,
+                            "timeout", String.valueOf(Math.max(0L, (p.expiresAt - System.currentTimeMillis()) / 1000L))));
+        });
     }
 
     private void onTpaSummon(PacketChannel channel, TpaSummonPacket pkt) {
         if (pkt == null) return;
-
         Player requester = Bukkit.getPlayer(pkt.getRequesterUuid());
-        if (requester == null) {
-            dbg("Summon received, but requester not online here: " + pkt.getRequesterUuid());
-            return;
-        }
+        if (requester == null) return;
 
-        var root = plugin.getSettingsConfig().getRoot();
-        var sec = root.getConfigurationSection("features.tpa");
+        OreScheduler.runForEntity(plugin, requester, () -> {
+            if (!requester.isOnline()) return;
 
-        boolean enabled = sec != null && sec.getBoolean("cooldown", false);
-        int seconds = (sec != null ? sec.getInt("cooldown-amount", 0) : 0);
+            var sec = plugin.getSettingsConfig().getRoot().getConfigurationSection("features.tpa");
+            boolean countdownEnabled = sec != null && sec.getBoolean("cooldown", false);
+            int seconds = sec != null ? sec.getInt("cooldown-amount", 0) : 0;
+            String destServer = pkt.getDestServer();
 
-        if (!enabled || seconds <= 0) {
-            boolean ok = connectToServer(requester, pkt.getDestServer());
-            if (ok) {
-                Lang.send(requester, "tpa.cross.connecting",
-                        "<gray>Connecting you to</gray> <yellow>%server%</yellow><gray>…</gray>",
-                        Map.of("server", pkt.getDestServer()));
-            } else {
-                plugin.getLogger().warning("[TPA-X] Could not send " + requester.getName()
-                        + " to server " + pkt.getDestServer() + " (no ProxyMessenger method matched)");
-            }
-            return;
-        }
-
-        final String destServer = pkt.getDestServer();
-        final Location origin = requester.getLocation().clone();
-
-        dbg("Starting cross-server TPA countdown for requester=" + requester.getName()
-                + " destServer=" + destServer + " seconds=" + seconds);
-
-        final int[] remain = {seconds};
-        final OreTask[] taskHolder = new OreTask[1];
-        taskHolder[0] = OreScheduler.runTimerForEntity(plugin, requester, () -> {
-            if (!requester.isOnline()) {
-                dbg("Requester went offline during cross-server countdown; cancel.");
-                taskHolder[0].cancel();
+            if (!countdownEnabled || seconds <= 0) {
+                connectAndNotify(requester, destServer);
                 return;
             }
 
-            if (hasBodyMoved(requester, origin)) {
-                Lang.send(requester, "teleport.countdown.cancelled-moved",
-                        "<red>Teleport cancelled: you moved.</red>");
-                dbg("Requester moved; cancelling cross-server countdown.");
-                taskHolder[0].cancel();
-                return;
-            }
-
-            if (remain[0] <= 0) {
-                taskHolder[0].cancel();
-                dbg("Cross-server countdown finished; connecting " + requester.getName() + " -> " + destServer);
-                boolean ok = connectToServer(requester, destServer);
-                if (ok) {
-                    Lang.send(requester, "tpa.cross.connecting",
-                            "<gray>Connecting you to</gray> <yellow>%server%</yellow><gray>…</gray>",
-                            Map.of("server", destServer));
-                } else {
-                    plugin.getLogger().warning("[TPA-X] Failed to connect " + requester.getName() + " to " + destServer);
+            Location origin = requester.getLocation().clone();
+            int[] remain = {seconds};
+            OreTask[] holder = new OreTask[1];
+            holder[0] = OreScheduler.runTimerForEntity(plugin, requester, () -> {
+                if (!requester.isOnline()) {
+                    holder[0].cancel();
+                    return;
                 }
-                return;
-            }
+                if (hasBodyMoved(requester, origin)) {
+                    Lang.send(requester, "teleport.countdown.cancelled-moved", "<red>Teleport cancelled: you moved.</red>");
+                    holder[0].cancel();
+                    return;
+                }
+                if (remain[0] <= 0) {
+                    holder[0].cancel();
+                    connectAndNotify(requester, destServer);
+                    return;
+                }
 
-            String title = Lang.msg("teleport.countdown.title", "<yellow>Teleporting…</yellow>", requester);
-            String subtitle = Lang.msgWithDefault("teleport.countdown.subtitle",
-                    "<gray>Teleporting in <white>%seconds%</white>s…</gray>",
-                    Map.of("seconds", String.valueOf(remain[0])), requester);
+                String title = Lang.msg("teleport.countdown.title", "<yellow>Teleporting…</yellow>", requester);
+                String subtitle = Lang.msgWithDefault("teleport.countdown.subtitle",
+                        "<gray>Teleporting in <white>%seconds%</white>s…</gray>",
+                        Map.of("seconds", String.valueOf(remain[0])), requester);
+                requester.sendTitle(title, subtitle, 0, 20, 0);
+                remain[0]--;
+            }, 0L, 20L);
+        });
+    }
 
-            requester.sendTitle(title, subtitle, 0, 20, 0);
-            remain[0]--;
-        }, 0L, 20L);
+    private void connectAndNotify(Player requester, String destServer) {
+        boolean ok = connectToServer(requester, destServer);
+        if (ok) {
+            Lang.send(requester, "tpa.cross.connecting",
+                    "<gray>Connecting you to</gray> <yellow>%server%</yellow><gray>…</gray>",
+                    Map.of("server", destServer));
+        } else {
+            plugin.getLogger().warning("[TPA-X] Failed to connect " + requester.getName() + " to " + destServer);
+        }
     }
 
     private boolean hasBodyMoved(Player p, Location origin) {
@@ -281,29 +222,33 @@ public final class TpaCrossServerBroker implements Listener {
 
     @EventHandler
     public void onJoin(PlayerJoinEvent e) {
-        UUID targetUuid = pendingArrival.remove(e.getPlayer().getUniqueId());
+        Player requester = e.getPlayer();
+        UUID targetUuid = pendingArrival.remove(requester.getUniqueId());
         if (targetUuid == null) return;
 
         Player target = Bukkit.getPlayer(targetUuid);
         if (target == null) {
-            Lang.send(e.getPlayer(), "tpa.arrival.target-offline", "<red>Teleport target went offline.</red>");
-            dbg("Arrival: target offline for requester=" + e.getPlayer().getName());
+            Lang.send(requester, "tpa.arrival.target-offline", "<red>Teleport target went offline.</red>");
             return;
         }
 
-        OreScheduler.runLaterForEntity(plugin, e.getPlayer(), () -> {
-            try {
-                Location to = target.getLocation();
-                if (OreScheduler.isFolia()) {
-                    e.getPlayer().teleportAsync(to);
-                } else {
-                    e.getPlayer().teleport(to);
-                }
-                dbg("Arrival: snapped " + e.getPlayer().getName() + " -> " + target.getName());
-            } catch (Throwable t) {
-                plugin.getLogger().warning("[TPA-X] Arrival teleport failed: " + t.getMessage());
+        // Capture the destination on the target's region, then teleport the requester on
+        // the requester's region. Never read target.getLocation() from another region.
+        OreScheduler.runForEntity(plugin, target, () -> {
+            if (!target.isOnline()) {
+                OreScheduler.runForEntity(plugin, requester, () ->
+                        Lang.send(requester, "tpa.arrival.target-offline", "<red>Teleport target went offline.</red>"));
+                return;
             }
-        }, 3L);
+            Location destination = target.getLocation().clone();
+            String targetName = target.getName();
+            OreScheduler.runLaterForEntity(plugin, requester, () -> {
+                if (!requester.isOnline()) return;
+                if (OreScheduler.isFolia()) requester.teleportAsync(destination);
+                else requester.teleport(destination);
+                dbg("Arrival: snapped " + requester.getName() + " -> " + targetName);
+            }, 3L);
+        });
     }
 
     @EventHandler
@@ -315,40 +260,22 @@ public final class TpaCrossServerBroker implements Listener {
         return pm != null && pm.isInitialized();
     }
 
-    private Player resolveTarget(UUID targetUuid, String targetName) {
+    private Player resolveOnlineTarget(UUID targetUuid, String targetName) {
         Player p = Bukkit.getPlayer(targetUuid);
         if (p != null) return p;
-
-        if (!offlineUuidCompat) return null;
-
-        if (targetName != null && !targetName.isBlank()) {
-            Player byExact = Bukkit.getPlayerExact(targetName);
-            if (byExact != null) return byExact;
-            String want = targetName.toLowerCase(java.util.Locale.ROOT);
-            for (Player op : Bukkit.getOnlinePlayers()) {
-                if (op.getName().equalsIgnoreCase(want)) return op;
-            }
+        if (!offlineUuidCompat || targetName == null || targetName.isBlank()) return null;
+        Player exact = Bukkit.getPlayerExact(targetName);
+        if (exact != null) return exact;
+        for (Player online : Bukkit.getOnlinePlayers()) {
+            if (online.getName().equalsIgnoreCase(targetName)) return online;
         }
-
-        try {
-            var dir = plugin.getPlayerDirectory();
-            if (dir != null) {
-                String lastKnownName = dir.lookupNameByUuid(targetUuid);
-                if (lastKnownName != null && !lastKnownName.isBlank()) {
-                    Player byExact = Bukkit.getPlayerExact(lastKnownName);
-                    if (byExact != null) return byExact;
-                    String want = lastKnownName.toLowerCase(java.util.Locale.ROOT);
-                    for (Player op : Bukkit.getOnlinePlayers()) {
-                        if (op.getName().equalsIgnoreCase(want)) return op;
-                    }
-                }
-            }
-        } catch (Throwable ignored) {}
-
+        // Intentionally no PlayerDirectory/Mongo lookup here: packet callbacks must never
+        // block a server/region thread. The packet already carries UUID + last-known name.
         return null;
     }
 
     private boolean connectToServer(Player player, String server) {
+        if (proxy == null || player == null || server == null || server.isBlank()) return false;
         try {
             for (String m : new String[]{"connect", "send", "sendToServer"}) {
                 Method method = find(proxy.getClass(), m, Player.class, String.class);
@@ -357,9 +284,6 @@ public final class TpaCrossServerBroker implements Listener {
                     return true;
                 }
             }
-        } catch (Throwable ignored) {}
-
-        try {
             for (String m : new String[]{"connect", "send", "sendToServer"}) {
                 Method method = find(proxy.getClass(), m, String.class);
                 if (method != null) {
@@ -368,7 +292,6 @@ public final class TpaCrossServerBroker implements Listener {
                 }
             }
         } catch (Throwable ignored) {}
-
         return false;
     }
 
@@ -384,28 +307,13 @@ public final class TpaCrossServerBroker implements Listener {
 
     private void purgeExpired() {
         long now = System.currentTimeMillis();
-        int removed = 0;
-        Iterator<Map.Entry<UUID, Pending>> it = pendingForTarget.entrySet().iterator();
-        while (it.hasNext()) {
-            Map.Entry<UUID, Pending> e = it.next();
-            Pending p = e.getValue();
-            if (p == null) {
-                it.remove();
-                removed++;
-                continue;
-            }
-            if (p.expiresAt > 0 && p.expiresAt < now) {
-                it.remove();
-                removed++;
-            }
-        }
-        if (removed > 0) dbg("Purged " + removed + " expired pending requests.");
+        pendingForTarget.entrySet().removeIf(e -> e.getValue() == null
+                || (e.getValue().expiresAt > 0 && e.getValue().expiresAt < now));
     }
 
     private void dbg(String msg) {
         try {
-            if (plugin.getConfig().getBoolean("features.tpa.debug",
-                    plugin.getConfig().getBoolean("debug", false))) {
+            if (plugin.getConfig().getBoolean("features.tpa.debug", plugin.getConfig().getBoolean("debug", false))) {
                 plugin.getLogger().info("[TPA-X@" + localServer + "] " + msg);
             }
         } catch (Throwable ignored) {}

--- a/src/main/java/fr/elias/oreoEssentials/rabbitmq/packet/PacketManager.java
+++ b/src/main/java/fr/elias/oreoEssentials/rabbitmq/packet/PacketManager.java
@@ -9,9 +9,9 @@ import fr.elias.oreoEssentials.rabbitmq.packet.event.IncomingPacketListener;
 import fr.elias.oreoEssentials.rabbitmq.packet.event.PacketSender;
 import fr.elias.oreoEssentials.rabbitmq.packet.event.PacketSubscriber;
 import fr.elias.oreoEssentials.rabbitmq.packet.event.PacketSubscriptionQueue;
-import fr.elias.oreoEssentials.modules.homes.rabbit.packet.HomeTeleportRequestPacket;
 import fr.elias.oreoEssentials.rabbitmq.stream.FriendlyByteInputStream;
 import fr.elias.oreoEssentials.rabbitmq.stream.FriendlyByteOutputStream;
+import fr.elias.oreoEssentials.util.OreScheduler;
 
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -37,34 +37,28 @@ public class PacketManager implements IncomingPacketListener {
         this.sender.registerListener(this);
     }
 
-    public void subscribeChannel(PacketChannel channel) {
-        this.sender.registerChannel(channel);
-    }
+    public void subscribeChannel(PacketChannel channel) { this.sender.registerChannel(channel); }
 
     public <T extends Packet> void registerPacket(Class<T> packetClass, Supplier<T> constructor) {
         try {
             packetRegistry.register(packetClass, constructor);
         } catch (NoSuchMethodError e) {
             boolean ok = tryReflectiveRegister(packetClass, constructor);
-            if (!ok) {
-                warn("[PM/REG] Failed to register packet " + packetClass.getName()
-                        + " — PacketRegistry has no compatible register(...) method.");
-            }
+            if (!ok) warn("[PM/REG] Failed to register packet " + packetClass.getName()
+                    + " — PacketRegistry has no compatible register(...) method.");
         } catch (Throwable t) {
             warn("[PM/REG] Error registering packet " + packetClass.getName() + ": " + t.getMessage());
         }
     }
 
     private <T extends Packet> boolean tryReflectiveRegister(Class<T> packetClass, Supplier<T> constructor) {
-        String[] names = {"register", "define", "put"};
-        for (String m : names) {
+        for (String m : new String[]{"register", "define", "put"}) {
             try {
                 var method = PacketRegistry.class.getMethod(m, Class.class, Supplier.class);
                 method.invoke(packetRegistry, packetClass, constructor);
                 return true;
             } catch (NoSuchMethodException ignored) {
-            } catch (Throwable ignored) {
-            }
+            } catch (Throwable ignored) {}
         }
         return false;
     }
@@ -78,14 +72,12 @@ public class PacketManager implements IncomingPacketListener {
             warn("[PM/PUBLISH] packet is null. channel=" + renderChannel(target));
             return;
         }
-
         if (!initialized) {
-            warn("[PM/PUBLISH] PacketManager not initialized (init() not called?)"
-                    + " type=" + packet.getClass().getName()
-                    + " channel=" + renderChannel(target));
+            warn("[PM/PUBLISH] PacketManager not initialized (init() not called?) type="
+                    + packet.getClass().getName() + " channel=" + renderChannel(target));
         }
 
-        PacketDefinition<?> definition = this.packetRegistry.getDefinition(packet.getClass());
+        PacketDefinition<?> definition = packetRegistry.getDefinition(packet.getClass());
         if (definition == null) {
             warn("[PM/PUBLISH] NO DEFINITION for type=" + packet.getClass().getName()
                     + " channel=" + renderChannel(target)
@@ -98,25 +90,20 @@ public class PacketManager implements IncomingPacketListener {
         packet.writeData(out);
 
         try {
-            this.sender.sendPacket(target, out.toByteArray());
+            sender.sendPacket(target, out.toByteArray());
         } catch (Throwable t) {
-            warn("[PM/PUBLISH] sender.sendPacket FAILED for type="
-                    + packet.getClass().getSimpleName()
-                    + " id=" + definition.getRegistryId()
-                    + " channel=" + renderChannel(target)
+            warn("[PM/PUBLISH] sender.sendPacket FAILED for type=" + packet.getClass().getSimpleName()
+                    + " id=" + definition.getRegistryId() + " channel=" + renderChannel(target)
                     + " error=" + t.getMessage());
         }
     }
 
-    public void sendPacket(Packet packet) {
-        sendPacket(PacketChannels.GLOBAL, packet);
-    }
+    public void sendPacket(Packet packet) { sendPacket(PacketChannels.GLOBAL, packet); }
 
     public <T extends Packet> void subscribe(Class<T> packetClass, PacketSubscriber<T> subscriber) {
         @SuppressWarnings("unchecked")
-        PacketSubscriptionQueue<T> queue =
-                (PacketSubscriptionQueue<T>) this.subscriptions.computeIfAbsent(
-                        packetClass, key -> new PacketSubscriptionQueue<>(packetClass));
+        PacketSubscriptionQueue<T> queue = (PacketSubscriptionQueue<T>) subscriptions.computeIfAbsent(
+                packetClass, key -> new PacketSubscriptionQueue<>(packetClass));
         queue.subscribe(subscriber);
     }
 
@@ -135,12 +122,9 @@ public class PacketManager implements IncomingPacketListener {
         try {
             FriendlyByteInputStream in = new FriendlyByteInputStream(content);
             long registryId = in.readLong();
-
-            PacketDefinition<?> definition = this.packetRegistry.getDefinition(registryId);
-
+            PacketDefinition<?> definition = packetRegistry.getDefinition(registryId);
             if (definition == null) {
-                warn("[PM/RECV] Unknown registry id: " + registryId
-                        + " bytes=" + content.length
+                warn("[PM/RECV] Unknown registry id: " + registryId + " bytes=" + content.length
                         + " channel=" + renderChannel(channel)
                         + " (Packet ids must match across servers; check register order & missing registerPacket calls)");
                 return;
@@ -148,24 +132,18 @@ public class PacketManager implements IncomingPacketListener {
 
             Packet packet = definition.getProvider().createPacket();
             packet.readData(in);
-
             dispatch(channel, packet);
-
         } catch (Throwable t) {
-            // R4: Log at SEVERE so packet decode failures are not silently swallowed.
             plugin.getLogger().log(java.util.logging.Level.SEVERE,
                     "[PM/RECV] Packet handling error — message rejected (not requeued)", t);
             warn("[PM/RECV] Failed to decode packet. err=" + t.getMessage()
-                    + " channel=" + renderChannel(channel)
-                    + " contentLen=" + content.length);
+                    + " channel=" + renderChannel(channel) + " contentLen=" + content.length);
         }
     }
 
     private <T extends Packet> void dispatch(PacketChannel channel, T packet) {
         @SuppressWarnings("unchecked")
-        PacketSubscriptionQueue<T> queue =
-                (PacketSubscriptionQueue<T>) this.subscriptions.get(packet.getClass());
-
+        PacketSubscriptionQueue<T> queue = (PacketSubscriptionQueue<T>) subscriptions.get(packet.getClass());
         if (queue == null) {
             warn("[PM/DISPATCH] No subscribers for " + packet.getClass().getName()
                     + " channel=" + renderChannel(channel)
@@ -173,24 +151,18 @@ public class PacketManager implements IncomingPacketListener {
             return;
         }
 
-        try {
-            queue.dispatch(channel, packet);
-        } catch (Throwable t) {
-            warn("[PM/DISPATCH] Subscriber dispatch failed for type="
-                    + packet.getClass().getSimpleName()
-                    + " err=" + t.getMessage()
-                    + " channel=" + renderChannel(channel));
-        }
-    }
-
-    private int safeSubscribersCount(PacketSubscriptionQueue<?> queue) {
-        try {
-            var m = queue.getClass().getMethod("size");
-            Object v = m.invoke(queue);
-            if (v instanceof Number n) return n.intValue();
-        } catch (Throwable ignored) {
-        }
-        return -1;
+        // RabbitMQ consumers run on RabbitMQ-owned threads. Never execute plugin/Bukkit
+        // subscriber code directly there. Move the dispatch onto the server scheduler first;
+        // entity-specific subscribers must still hop to the relevant entity scheduler.
+        OreScheduler.run(plugin, () -> {
+            try {
+                queue.dispatch(channel, packet);
+            } catch (Throwable t) {
+                warn("[PM/DISPATCH] Subscriber dispatch failed for type="
+                        + packet.getClass().getSimpleName() + " err=" + t.getMessage()
+                        + " channel=" + renderChannel(channel));
+            }
+        });
     }
 
     private String renderChannel(PacketChannel ch) {
@@ -208,37 +180,9 @@ public class PacketManager implements IncomingPacketListener {
         }
     }
 
-    private String serverName() {
-        try {
-            return plugin.getConfigService().serverName();
-        } catch (Throwable t) {
-            return "unknown";
-        }
-    }
-
-    private void warn(String msg) {
-        plugin.getLogger().warning(msg);
-    }
-
-    private void dbg(String msg) {
-        if (isDebug()) plugin.getLogger().info(msg);
-    }
-
-    private boolean isDebug() {
-        try {
-            return plugin.getConfig().getBoolean("debug", false);
-        } catch (Throwable t) {
-            return false;
-        }
-    }
-
-    public PacketRegistry getPacketRegistry() {
-        return packetRegistry;
-    }
-
-    public boolean isInitialized() {
-        return initialized;
-    }
+    private void warn(String msg) { plugin.getLogger().warning(msg); }
+    public PacketRegistry getPacketRegistry() { return packetRegistry; }
+    public boolean isInitialized() { return initialized; }
 
     public void close() {
         initialized = false;
@@ -246,10 +190,7 @@ public class PacketManager implements IncomingPacketListener {
     }
 
     public String registryChecksum() {
-        try {
-            return Integer.toHexString(packetRegistry.hashCode());
-        } catch (Throwable t) {
-            return "n/a";
-        }
+        try { return Integer.toHexString(packetRegistry.hashCode()); }
+        catch (Throwable t) { return "n/a"; }
     }
 }

--- a/src/main/java/fr/elias/oreoEssentials/rabbitmq/sender/RabbitMQSender.java
+++ b/src/main/java/fr/elias/oreoEssentials/rabbitmq/sender/RabbitMQSender.java
@@ -10,7 +10,6 @@ import fr.elias.oreoEssentials.rabbitmq.packet.event.IncomingPacketListener;
 import fr.elias.oreoEssentials.rabbitmq.packet.event.PacketSender;
 
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executors;
@@ -21,31 +20,21 @@ import java.util.function.BooleanSupplier;
 
 public class RabbitMQSender implements PacketSender {
 
-    // ---- Broadcast (GLOBAL) fanout exchange ----
-    // All servers publish to this exchange, each server has its own queue bound to it.
     private static final String GLOBAL_FANOUT_EXCHANGE = "oreo.global.fanout";
-    // Queue name pattern for each server: oreo.global.<serverName>
     private static final String GLOBAL_QUEUE_PREFIX = "oreo.global.";
 
     private final String connectionString;
-    private final String serverName; // IMPORTANT: must be unique per backend (ex shard-0-0, shard-0-1)
+    private final String serverName;
     private final BooleanSupplier debugEnabled;
 
     private volatile Connection connection;
     private volatile Channel channel;
 
     private final List<IncomingPacketListener> listeners = new ArrayList<>();
-
-    // We store "logical ids" (e.g. "global", "homes", "chat") that we are subscribed to.
     private final Set<String> subscribedLogicalIds = ConcurrentHashMap.newKeySet();
-
-    // We store physical queue names we actually consume from (e.g. "global" OR "oreo.global.shard-0-0").
     private final Set<String> consumingQueues = ConcurrentHashMap.newKeySet();
-
-    // Track consumer tags so we can avoid duplicate consumers after reconnect.
     private final Map<String, String> consumerTagsByQueue = new ConcurrentHashMap<>();
 
-    // Reconnect backoff state
     private final ScheduledExecutorService reconnectScheduler =
             Executors.newSingleThreadScheduledExecutor(r -> {
                 Thread t = new Thread(r, "OreoEssentials-RMQ-Reconnect");
@@ -54,6 +43,7 @@ public class RabbitMQSender implements PacketSender {
             });
     private final AtomicInteger reconnectAttempts = new AtomicInteger(0);
     private volatile boolean reconnecting = false;
+    private volatile boolean closed = false;
 
     public RabbitMQSender(String connectionString, String serverName) {
         this(connectionString, serverName, () -> false);
@@ -67,74 +57,52 @@ public class RabbitMQSender implements PacketSender {
 
     @Override
     public void sendPacket(PacketChannel packetChannel, byte[] content) {
+        if (closed) return;
         try {
             ensureConnected();
-
             for (String id : packetChannel) {
                 if (id == null || id.isBlank()) continue;
-
-                // GLOBAL must be a broadcast (fanout exchange)
                 if ("global".equalsIgnoreCase(id)) {
-                    // Fanout ignores routing key, but basicPublish requires one -> use empty string
                     channel.basicPublish(GLOBAL_FANOUT_EXCHANGE, "", null, content);
-
                     dbg("[RMQ/SEND@" + serverName + "] GLOBAL fanout exchange=" + GLOBAL_FANOUT_EXCHANGE
                             + " bytes=" + content.length);
-                    continue;
+                } else {
+                    channel.basicPublish("", id, null, content);
+                    dbg("[RMQ/SEND@" + serverName + "] direct queue=" + id + " bytes=" + content.length);
                 }
-
-                // Everything else: keep your existing behavior (direct to queue via default exchange)
-                channel.basicPublish("", id, null, content);
-
-                dbg("[RMQ/SEND@" + serverName + "] direct queue=" + id + " bytes=" + content.length);
             }
-
-        } catch (IOException e) {
-            System.err.println("[OreoEssentials] ❌ Failed to send RabbitMQ message.");
-            e.printStackTrace();
+        } catch (Exception e) {
+            System.err.println("[OreoEssentials] ❌ Failed to send RabbitMQ message: " + e.getMessage());
             reconnect();
         }
     }
 
     @Override
     public void registerChannel(PacketChannel packetChannel) {
+        if (closed) return;
         try {
             ensureConnected();
-
             for (String id : packetChannel) {
                 if (id == null || id.isBlank()) continue;
                 final String logicalId = id.trim();
+                if (!subscribedLogicalIds.add(logicalId)) continue;
 
-                if (!subscribedLogicalIds.add(logicalId)) {
-                    // already registered
-                    continue;
-                }
-
-                // GLOBAL = fanout exchange + per-server queue
                 if ("global".equalsIgnoreCase(logicalId)) {
                     declareGlobalFanout();
                     String globalQueue = GLOBAL_QUEUE_PREFIX + serverName;
-
                     declareQueue(globalQueue);
                     bindQueueToGlobalFanout(globalQueue);
                     startConsumer(globalQueue);
-
                     dbg("[RMQ/REG@" + serverName + "] channel=global -> queue=" + globalQueue
                             + " exchange=" + GLOBAL_FANOUT_EXCHANGE);
-                    continue;
+                } else {
+                    declareQueue(logicalId);
+                    startConsumer(logicalId);
+                    dbg("[RMQ/REG@" + serverName + "] channel=" + logicalId + " -> directQueue=" + logicalId);
                 }
-
-                // Other channels: old behavior (each server consumes the same queue name)
-                // NOTE: this is "competing consumers" by design. It's fine for targeted queues,
-                // but DON'T use it for broadcast.
-                declareQueue(logicalId);
-                startConsumer(logicalId);
-
-                dbg("[RMQ/REG@" + serverName + "] channel=" + logicalId + " -> directQueue=" + logicalId);
             }
         } catch (Exception e) {
-            System.err.println("[OreoEssentials] ❌ Failed to register channel(s)!");
-            e.printStackTrace();
+            System.err.println("[OreoEssentials] ❌ Failed to register channel(s): " + e.getMessage());
             reconnect();
         }
     }
@@ -147,238 +115,177 @@ public class RabbitMQSender implements PacketSender {
     }
 
     private synchronized void ensureConnected() {
+        if (closed) throw new IllegalStateException("RabbitMQ sender is closed");
+        if (connection != null && connection.isOpen() && channel != null && channel.isOpen()) return;
+        if (!connect()) throw new IllegalStateException("RabbitMQ reconnect failed");
         try {
-            if (connection != null && connection.isOpen() && channel != null && channel.isOpen()) return;
-            connect();
             rebindAllConsumers();
-        } catch (Exception e) {
-            throw new IllegalStateException("RabbitMQ not connected and reconnect failed", e);
+        } catch (IOException e) {
+            closeConnectionOnly();
+            throw new IllegalStateException("RabbitMQ consumer rebind failed", e);
         }
     }
 
     private void reconnect() {
-        // Guard: only schedule one reconnect attempt at a time
-        if (reconnecting) {
-            return;
+        if (closed || reconnectScheduler.isShutdown()) return;
+        synchronized (this) {
+            if (reconnecting) return;
+            reconnecting = true;
         }
-        reconnecting = true;
 
         int attempt = reconnectAttempts.getAndIncrement();
-        // Exponential backoff: 1s, 2s, 4s, 8s, ... capped at 30s
-        long delaySeconds = Math.min((long) Math.pow(2, attempt), 30L);
-
+        long delaySeconds = Math.min(1L << Math.min(attempt, 5), 30L);
         System.err.println("[OreoEssentials] Scheduling RabbitMQ reconnect attempt #" + (attempt + 1)
                 + " in " + delaySeconds + "s...");
 
         reconnectScheduler.schedule(() -> {
             reconnecting = false;
+            if (closed) return;
+
             System.err.println("[OreoEssentials] Attempting to reconnect to RabbitMQ (attempt #" + (attempt + 1) + ")...");
-            close();
+            closeConnectionOnly();
+
             if (connect()) {
-                reconnectAttempts.set(0);
-                System.out.println("[OreoEssentials] Successfully reconnected to RabbitMQ!");
                 try {
                     rebindAllConsumers();
+                    reconnectAttempts.set(0);
+                    System.out.println("[OreoEssentials] Successfully reconnected to RabbitMQ!");
                 } catch (Exception e) {
-                    System.err.println("[OreoEssentials] Failed to rebind consumers after reconnect:");
-                    e.printStackTrace();
+                    System.err.println("[OreoEssentials] Failed to rebind consumers after reconnect: " + e.getMessage());
+                    closeConnectionOnly();
+                    reconnect();
                 }
             } else {
-                System.err.println("[OreoEssentials] Reconnection attempt #" + (attempt + 1) + " failed. Will retry...");
                 reconnect();
             }
         }, delaySeconds, TimeUnit.SECONDS);
     }
 
-    public boolean connect() {
+    public synchronized boolean connect() {
+        if (closed) return false;
         try {
+            if (connection != null && connection.isOpen() && channel != null && channel.isOpen()) return true;
+
             ConnectionFactory factory = new ConnectionFactory();
             factory.setUri(connectionString);
             factory.setAutomaticRecoveryEnabled(true);
             factory.setNetworkRecoveryInterval(5000);
-            factory.setConnectionTimeout(5000);   // 5 s — prevents blocking the server thread on startup
+            factory.setConnectionTimeout(5000);
             factory.setHandshakeTimeout(5000);
 
             connection = factory.newConnection();
             channel = connection.createChannel();
+            if (subscribedLogicalIds.contains("global")) declareGlobalFanout();
 
-            // declare required infrastructure if global is used
-            if (subscribedLogicalIds.contains("global")) {
-                declareGlobalFanout();
-            }
-
-            System.out.println("[OreoEssentials]  Connected to RabbitMQ successfully!");
+            System.out.println("[OreoEssentials] Connected to RabbitMQ successfully!");
             dbg("[RMQ/CONNECT@" + serverName + "] channelOpen=" + channel.isOpen());
-
             return true;
         } catch (Exception e) {
-            System.err.println("[OreoEssentials] ❌ Failed to connect to RabbitMQ!");
-            e.printStackTrace();
+            System.err.println("[OreoEssentials] ❌ Failed to connect to RabbitMQ: " + e.getMessage());
+            closeConnectionOnly();
             return false;
         }
     }
 
+    @Override
     public void close() {
-        reconnectScheduler.shutdownNow();
+        closed = true;
         reconnecting = false;
+        reconnectScheduler.shutdownNow();
+        closeConnectionOnly();
+    }
+
+    private synchronized void closeConnectionOnly() {
         try {
-            // Try to cancel consumers (best-effort)
             for (Map.Entry<String, String> entry : consumerTagsByQueue.entrySet()) {
-                String q = entry.getKey();
                 String tag = entry.getValue();
                 if (tag != null && channel != null && channel.isOpen()) {
-                    try {
-                        channel.basicCancel(tag);
-                        dbg("[RMQ/CANCEL@" + serverName + "] queue=" + q + " tag=" + tag);
-                    } catch (Exception e) {
-                        System.err.println("[RabbitMQ] Failed to cancel consumer tag " + tag + ": " + e.getMessage());
-                    }
+                    try { channel.basicCancel(tag); } catch (Exception ignored) {}
                 }
             }
-
             consumerTagsByQueue.clear();
             consumingQueues.clear();
-
-            if (channel != null) {
-                try { channel.close(); } catch (Exception ignore) {}
-            }
-            if (connection != null) {
-                try { connection.close(); } catch (Exception ignore) {}
-            }
+            if (channel != null) try { channel.close(); } catch (Exception ignored) {}
+            if (connection != null) try { connection.close(); } catch (Exception ignored) {}
         } finally {
             channel = null;
             connection = null;
-            System.out.println("[OreoEssentials]  RabbitMQ connection closed.");
         }
     }
 
     private void declareQueue(String name) throws IOException {
-        // durable = true, exclusive = false, autoDelete = false
         channel.queueDeclare(name, true, false, false, null);
-        dbg("[RMQ/QUEUE@" + serverName + "] declared queue=" + name);
     }
 
     private void declareGlobalFanout() throws IOException {
         channel.exchangeDeclare(GLOBAL_FANOUT_EXCHANGE, BuiltinExchangeType.FANOUT, true);
-        dbg("[RMQ/XCHG@" + serverName + "] declared fanout exchange=" + GLOBAL_FANOUT_EXCHANGE);
     }
 
     private void bindQueueToGlobalFanout(String queue) throws IOException {
         channel.queueBind(queue, GLOBAL_FANOUT_EXCHANGE, "");
-        dbg("[RMQ/BIND@" + serverName + "] queue=" + queue + " -> exchange=" + GLOBAL_FANOUT_EXCHANGE);
     }
 
     private void startConsumer(String queue) throws IOException {
         if (queue == null || queue.isBlank()) return;
-
-        // avoid duplicate consumers
-        if (!consumingQueues.add(queue)) {
-            dbg("[RMQ/CONS@" + serverName + "] already consuming queue=" + queue);
-            return;
-        }
+        if (!consumingQueues.add(queue)) return;
 
         String tag = channel.basicConsume(queue, false, (consumerTag, delivery) -> {
+            Channel deliveryChannel = channel;
             try {
                 byte[] content = delivery.getBody();
-                dbg("[RMQ/RECV@" + serverName + "] queue=" + queue
-                        + " bytes=" + content.length
-                        + " deliveryTag=" + delivery.getEnvelope().getDeliveryTag());
-
                 handleIncomingPacket(queue, content);
-
-                channel.basicAck(delivery.getEnvelope().getDeliveryTag(), false);
-            } catch (Exception ex) {
-                // R4: reject WITHOUT requeue (requeue=false) to avoid infinite redelivery loop.
-                // Log raw hex bytes for post-mortem debugging.
-                byte[] rawBody = delivery.getBody();
-                StringBuilder hex = new StringBuilder();
-                for (int bi = 0; bi < Math.min(rawBody.length, 64); bi++) {
-                    hex.append(String.format("%02x", rawBody[bi]));
+                if (deliveryChannel != null && deliveryChannel.isOpen()) {
+                    deliveryChannel.basicAck(delivery.getEnvelope().getDeliveryTag(), false);
                 }
+            } catch (Exception ex) {
                 System.err.println("[OreoEssentials] SEVERE packet handler threw on queue=" + queue
                         + " deliveryTag=" + delivery.getEnvelope().getDeliveryTag()
-                        + " rawHex(first64)=" + hex
                         + " error=" + ex.getMessage());
-                ex.printStackTrace();
                 try {
-                    channel.basicNack(delivery.getEnvelope().getDeliveryTag(), false, false);
-                } catch (IOException ioEx) {
-                    System.err.println("[OreoEssentials] basicNack failed: " + ioEx.getMessage());
-                }
+                    if (deliveryChannel != null && deliveryChannel.isOpen()) {
+                        deliveryChannel.basicNack(delivery.getEnvelope().getDeliveryTag(), false, false);
+                    }
+                } catch (IOException ignored) {}
             }
-        }, consumerTag -> {
-            dbg("[RMQ/CANCELLED@" + serverName + "] consumerTag=" + consumerTag + " queue=" + queue);
-        });
+        }, consumerTag -> dbg("[RMQ/CANCELLED@" + serverName + "] consumerTag=" + consumerTag + " queue=" + queue));
 
         consumerTagsByQueue.put(queue, tag);
-        dbg("[RMQ/CONS@" + serverName + "] started consumer queue=" + queue + " tag=" + tag);
     }
 
     private void rebindAllConsumers() throws IOException {
-        dbg("[RMQ/REBIND@" + serverName + "] subscribedLogicalIds=" + subscribedLogicalIds);
-
-        // Important: after reconnect, our channel changed, consumer tags are invalid.
         consumerTagsByQueue.clear();
         consumingQueues.clear();
-
-        // Snapshot the logical IDs we need to re-register, then clear the set so
-        // registerChannel()'s early-return guard ("already registered") is bypassed
-        // and each consumer is properly re-bound to the new channel.
         List<String> toRebind = new ArrayList<>(subscribedLogicalIds);
         subscribedLogicalIds.clear();
-
-        // Re-register each logical subscription to rebuild infra + consumers
         for (String logical : toRebind) {
-            // reuse existing method to keep logic identical
             registerChannel(PacketChannels.individual(logical));
         }
     }
 
     private void handleIncomingPacket(String queueId, byte[] content) {
-        try {
-            // Map physical queue -> logical channel id
-            // - global fanout queue: oreo.global.<serverName> => logical "global"
-            // - other queues: logical == queue name
-            final String logicalId;
-            if (queueId != null && queueId.startsWith(GLOBAL_QUEUE_PREFIX)) {
-                logicalId = "global";
-            } else {
-                logicalId = queueId;
-            }
+        String logicalId = queueId != null && queueId.startsWith(GLOBAL_QUEUE_PREFIX) ? "global" : queueId;
+        PacketChannel logical = PacketChannels.individual(logicalId);
 
-            PacketChannel logical = PacketChannels.individual(logicalId);
-
-            List<IncomingPacketListener> snapshot;
-            synchronized (listeners) {
-                snapshot = new ArrayList<>(listeners);
+        List<IncomingPacketListener> snapshot;
+        synchronized (listeners) {
+            snapshot = new ArrayList<>(listeners);
+        }
+        for (IncomingPacketListener listener : snapshot) {
+            try {
+                listener.onReceive(logical, content);
+            } catch (Throwable t) {
+                System.err.println("[OreoEssentials] ❌ Listener threw while handling incoming packet: " + t.getMessage());
             }
-
-            for (IncomingPacketListener listener : snapshot) {
-                try {
-                    listener.onReceive(logical, content);
-                } catch (Throwable t) {
-                    System.err.println("[OreoEssentials] ❌ Listener threw while handling incoming packet:");
-                    t.printStackTrace();
-                }
-            }
-        } catch (Exception e) {
-            System.err.println("[OreoEssentials] ❌ Error while handling incoming packet!");
-            e.printStackTrace();
         }
     }
 
     private void dbg(String msg) {
-        // keep simple: always log RMQ debug to stdout (or change to plugin logger if you pass plugin here)
-        // If you want it gated by config.debug, tell me and I’ll wire it.
         if (!isDebugEnabled()) return;
         System.out.println("[OreoEssentials] " + msg);
     }
 
     private boolean isDebugEnabled() {
-        try {
-            return debugEnabled.getAsBoolean();
-        } catch (Throwable ignored) {
-            return false;
-        }
+        try { return debugEnabled.getAsBoolean(); }
+        catch (Throwable ignored) { return false; }
     }
 }


### PR DESCRIPTION
Second stability sweep for Folia and cross-server behavior.

Fixes:
- RabbitMQ packet subscribers no longer execute directly on RabbitMQ consumer threads
- RabbitMQ reconnect no longer destroys its own retry executor
- cross-server TPA target/requester region access
- /top and /bottom use Folia-safe async teleports
- /tphere captures sender position on the sender region and avoids blocking Mongo tab-completion lookups
- FreezeManager player effects/messages run on entity schedulers
- TempFly mutations run on entity schedulers
- Jail guard uses concurrent state and per-player region scheduling
- ClearLag cancels/restarts its TPS sampler correctly and avoids global World#getEntities scans on Folia
- Playtime YAML writes are moved off tick/player threads
- cross-server portal teleports/connects use player entity scheduling
- HealthBarListener automatically retires the previous listener/sweeper on reload

Does not modify CommandManager.